### PR TITLE
Adding members page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# InnerSource Commons New Website
+# InnerSource Commons Website
 
-Work in progress
+This repo is powering the InnerSource Commons Website at [innersourcecommons.org](https://innersourcecommons.org).
 
 The site is built with Hugo framework. All content is located at the `content` folder.
 
@@ -12,7 +12,7 @@ Create a Pull Request and after the review changes will be automatically uploade
 
 ### Adding Widgets
 
-If you are adding any widgets to the site, please check if they add cookies by clicking the lock in front of the URL in your browser and checking the cookies before and after you add the widget. 
+If you are adding any widgets to the site, please check if they add cookies by clicking the lock in front of the URL in your browser and checking the cookies before and after you add the widget.
 
 In case the widget adds cookies to the website plese update the Privacy Policy (content/about/privacy.md) with the new cookies.
 
@@ -23,6 +23,6 @@ you need to have `git` and [hugo](https://gohugo.io/getting-started/installing/)
 
 ```
 $ git clone [url]
-$ cd innersourcecommons.net
+$ cd innersourcecommons.org
 $ hugo server
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -39,14 +39,18 @@ menu:
       URL: about/board
       parent: about
       weight: 1
+    - name: Members
+      URL: about/members
+      parent: about
+      weight: 2
     - name: Code of Conduct
       URL: about/codeofconduct
       parent: about
-      weight: 2
+      weight: 3
     - name: Contact Us
       URL: about/contact
       parent: about
-      weight: 3
+      weight: 4
   footer_left:
     - name: Learn
       URL: learn
@@ -82,15 +86,18 @@ menu:
     - name: Board & Governance
       URL: about/board
       weight: 2
+    - name: Members
+      URL: about/members
+      weight: 3
     - name: Code of Conduct
       URL: about/codeofconduct
-      weight: 3
+      weight: 4
     - name: Contact Us
       URL: about/contact
-      weight: 4
+      weight: 5
     - name: Privacy Policy
       URL: about/privacy
-      weight: 5
+      weight: 6
 languages:
   en:
     languageName: English

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -62,6 +62,7 @@ draft: false
         <p>The InnerSource Commons community is open to all. Some community participants go above and beyond, and may be invited to become an ISC Member. The InnerSource Commons is a membership corporation, so ISC Members serve a similar role as shareholders in publicly traded corporations. </p>
         <p>Members have particular rights in the ISC; for example, they may vote in board elections. To be eligible for Membership, a person must be nominated by a current Member. Membership is purely merit-based, free of any cost, and restricted to individuals.
         </p>
+        <a href="/about/members" class="btn-link">All InnerSource Commons Members <i class="ti-arrow-right"></i></a>
       </div>
       <div class="col-md-6 mt-4 mb-4 mb-md-0 float-right">
         <img src="/images/about/illustrations/notebook.png" class="img-fluid pl-4 pr-4">

--- a/content/about/members.md
+++ b/content/about/members.md
@@ -1,0 +1,31 @@
+---
+title: "Members"
+subtitle: ""
+description: "Some community participants go above and beyond, and may be invited to become an ISC Member."
+image: "/images/logo.png"
+---
+
+The InnerSource Commons (ISC) community is open to all. Some community participants go above and beyond, and may be invited to become an ISC Member. The InnerSource Commons is a membership corporation, so ISC Members serve a similar role as shareholders in publicly traded corporations.
+
+Members have particular rights in the ISC; for example, they may vote in board elections. To be eligible for Membership, a person must be nominated by a current Member. Membership is purely merit-based, free of any cost, and restricted to individuals.
+
+## Members of the InnerSource Commons Foundation
+
+* Cedric Williams
+* Clare Dillon
+* Danese Cooper
+* Daniel Izquierdo
+* Dmitrii Sugrobov
+* Fei Wan
+* Georg Grütter
+* Isabel Drost-Fromm
+* Jacob Green
+* Jerry Tan
+* Johannes Tigers
+* Klaas-Jan Stol
+* Max Capraro
+* Russ Rutledge
+* Sebastian Spier
+* Silona Bonewald
+* Tim Yao
+* Tom Sadler

--- a/content/about/members.md
+++ b/content/about/members.md
@@ -14,6 +14,7 @@ Membership is purely merit-based, free of any cost, and restricted to individual
 
 ## Members of the InnerSource Commons Foundation
 
+* Ada Dai
 * Cedric Williams
 * Clare Dillon
 * Danese Cooper

--- a/content/about/members.md
+++ b/content/about/members.md
@@ -5,9 +5,12 @@ description: "Some community participants go above and beyond, and may be invite
 image: "/images/logo.png"
 ---
 
-The InnerSource Commons (ISC) community is open to all. Some community participants go above and beyond, and may be invited to become an ISC Member. The InnerSource Commons is a membership corporation, so ISC Members serve a similar role as shareholders in publicly traded corporations.
+The InnerSource Commons (ISC) community is open to all. Some community participants go above and beyond, and may be invited to become an ISC Member.
+The InnerSource Commons is a membership corporation, so ISC Members serve a similar role as shareholders in publicly traded corporations.
 
-Members have particular rights in the ISC; for example, they may vote in board elections. To be eligible for Membership, a person must be nominated by a current Member. Membership is purely merit-based, free of any cost, and restricted to individuals.
+Members have particular rights in the ISC; for example, they may vote in board elections.
+To be eligible for Membership, a person must be nominated by a current Member.
+Membership is purely merit-based, free of any cost, and restricted to individuals.
 
 ## Members of the InnerSource Commons Foundation
 

--- a/content/about/members.md
+++ b/content/about/members.md
@@ -17,17 +17,17 @@ Membership is purely merit-based, free of any cost, and restricted to individual
 * Cedric Williams
 * Clare Dillon
 * Danese Cooper
-* Daniel Izquierdo
+* Daniel Izquierdo Cortazar
 * Dmitrii Sugrobov
 * Fei Wan
-* Georg Grütter
+* Georg Grutter
 * Isabel Drost-Fromm
 * Jacob Green
 * Jerry Tan
-* Johannes Tigers
+* Johannes Tigges
 * Klaas-Jan Stol
-* Max Capraro
-* Russ Rutledge
+* Maximilian Capraro
+* Russel Rutledge
 * Sebastian Spier
 * Silona Bonewald
 * Tim Yao


### PR DESCRIPTION
The text shown on this new Members page is the same that we already use on https://innersourcecommons.org/about/. 

We could elaborate further on how Members are elected, how Emeritus status works, etc. 
Similar to how it is done at the [ASF Members page](https://www.apache.org/foundation/members.html).

However I would recommend to do that at a later point, in order to get the first version of this page out.

## Minimum requirements for this to be ready for review:

- [x] double check spellings of all names
- [x] add last missing Members

## Other changes in this PR:

- mini improvements to `README.md`