### PR TITLE
Update link to Metrics book (Managing Inner Source Projects)

### DIFF
--- a/content/learn/books/managing-innersource-projects.md
+++ b/content/learn/books/managing-innersource-projects.md
@@ -7,7 +7,7 @@ summary: "How to manage InnerSource projects? In this book Daniel Izquierdo & Jo
 book_author: Daniel Izquierdo & José Manrique López
 book_publish_date: 2018
 book_publisher: InnerSource Commons
-book_url: https://dicortazar.gitbook.io/managing-inner-source-projects/
+book_url: https://innersourcecommons.gitbook.io/managing-inner-source-projects/
 ---
 
 This book is intended to bring, from a managerial perspective, the several aspects needed when introducing InnerSource methodologies into enterprises.


### PR DESCRIPTION
bitergia is donating the Metrics book to the InnerSource Commons foundation. 

As part of moving those assets around in GitHub/GitBook, the URL of the book has changed to https://innersourcecommons.gitbook.io/managing-inner-source-projects/