### PR TITLE
Add French language to config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -120,6 +120,9 @@ languages:
   ru:
     languageName: Русский
     weight: 2
+  fr:
+    languageName: Français
+    weight: 2
 paginate: '3'
 summaryLength: '15'
 disqusShortname: ''


### PR DESCRIPTION
Bug introduced in #134 - translations and introduction section broken. Website needs to be made aware of all translations supplied in the markdown.