### PR TITLE
Terse notes board meeting 2021-07-21

### DIFF
--- a/content/about/board/2021-07-21.md
+++ b/content/about/board/2021-07-21.md
@@ -1,0 +1,37 @@
+---
+layout: page
+show_meta: false
+title: 'Terse Notes from Board Meeting on 2021-07-21'
+---
+
+### Date and Time of Meeting
+
+2021-07-21, 7 p.m - 8 p.m. CEST / 12 a.m. - 1 p.m. CDT
+Call to order 19:04 CEST - Adjourned 19:52 CEST
+
+### Role Call
+
+#### Directors Present
+
+- Danese Cooper (Chair)
+- Jacob Green
+- Johannes Tigges (Assistant Secretary)
+- Isabel Drost-Fromm (President)
+- Cedric Williams (Treasurer)
+- Daniel Izquierdo
+
+
+#### Directors Absent
+
+- Georg Grütter (Vice President)
+- Russel Rutledge (Secretary)
+- Max Capraro (proxied by Johannes Tigges)
+
+#### Members Present
+
+
+### Votes Taken
+
+- Email vote taken in between meetings and ratified in the meeting: 
+  - Danese moved to proceed with registering 4 terms related to InnerSource as a trademark. Estimated cost is $4,000 USD.
+  - Ratified in the meeting (7/0/2), (7/0/2) (yes/no/abstain) votes by email.

--- a/content/about/board/2021-07-21.md
+++ b/content/about/board/2021-07-21.md
@@ -24,7 +24,7 @@ Call to order 19:04 CEST - Adjourned 19:52 CEST
 #### Directors Absent
 
 - Georg Grütter (Vice President)
-- Russel Rutledge (Secretary)
+- Russell Rutledge (Secretary)
 - Max Capraro (proxied by Johannes Tigges)
 
 #### Members Present


### PR DESCRIPTION
This represents the terse notes of the 2021-07-21 board meeting. 
Directors: Please all review and indicate acceptance/change requests/rejection by means of +1/comment/-1 reviews
