### PR TITLE
fix: Social image default with page override

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -173,6 +173,7 @@ params:
   themeVariant: quizdown
   description: The InnerSource Commons is a growing community of practitioners with the goal of creating and sharing knowledge about InnerSource.
   author: InnerSource Commons
+  defaultImage: images/logo.png
   footer_content: >-
     The site is licensed under a CC-BY-SA license unless otherwise marked.
   copyright: >-

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,8 +38,14 @@
   {{ end }}
   
   {{ template "_internal/opengraph.html" . }}
-  {{ with .Params.Image }}
-  <meta property="og:image" content="{{ . | absURL }}" />
+  {{ if .Params.Image }}
+    {{ with .Params.Image }}
+    <meta property="og:image" content="{{ . | absURL }}" />
+    {{ end }}
+  {{else}}
+    {{ with site.Params.defaultImage }}
+    <meta property="og:image" content="{{ . | absURL }}" />
+    {{ end }}
   {{ end }}
-  
+
 </head>


### PR DESCRIPTION
Pages did not always have a social image unless one was explicitly
set. Since there was no requirement for an image to be set, this
resulted in many pages not having a nice graphic when shared.

This fix creates a site defaultImage variable and sets it. All
subsequent pages will us that unless a page-level image is set.
This ensures backwards compatibility and a nice image going
forward.

fixes #171