### PR TITLE
Created announcements widget to make this visible

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -27,6 +27,10 @@ a:hover, .content a:hover {
     padding-top: 20px;
 }
 
+.section-last {
+    padding-top: 0;
+}
+
 .section-small {
     padding-top: 30px;
     padding-bottom: 30px;

--- a/content/_index.md
+++ b/content/_index.md
@@ -76,7 +76,23 @@ title: "InnerSource Commons"
   </div>
 </section>
 
+
 <section class="section">
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="offset-md-2 col-md-4 mb-4 mb-md-0">
+        {{< announcements >}}
+      </div>
+      <div class="col-md-5">
+        <p class="section-title h2">InnerSource Commons Foundation</p>
+        <p>InnerSource Commons is a 501(c)(3) non-profit organization governed by a set of corporate bylaws.</p>
+        <p><a href="/about/" class="btn-link">About Foundation <i class="ti-arrow-right"></i></a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-last section">
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -9,7 +9,7 @@ draft: false
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-4 mb-4 mb-md-0">
-        <img src="/images/logo-big.png" class="img-fluid logo-home pr-4">
+        {{< announcements >}}
       </div>
       <div class="col-md-7">
         <p>The InnerSource Commons is a growing community of practitioners with the goal of creating and sharing knowledge about InnerSource. Founded in 2015, the InnerSource Commons is now supporting and connecting over 1000 individuals from over 400 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.

--- a/layouts/shortcodes/announcements.html
+++ b/layouts/shortcodes/announcements.html
@@ -1,0 +1,3 @@
+<div class="slider">{{ $pages := where .Page.Site.Pages "Type" "in" "announcements" }}{{ $pages = where $pages "Kind" "in" "page" }}{{ range first 3 $pages }}
+<a href="{{ .Permalink }}"><img src="/{{ .Param "image" }}" alt="" class="img-fluid"></a>
+{{ end }}</div>


### PR DESCRIPTION
Created a special announcements slider to have the ability to show the last 3 announcements. 

How to use: put `{{< announcements >}}` to any page

Placed in homepage and about section.

![image](https://user-images.githubusercontent.com/9394918/137806923-09f5f289-b0df-4bca-9d2a-763472c125a5.png)

Not sure I have the right texts around, will be happy to have your ideas on text and placement.