### PR TITLE
VIdeo links for events

### DIFF
--- a/content/events/isc-apac-dec-2020.md
+++ b/content/events/isc-apac-dec-2020.md
@@ -2,6 +2,7 @@
 title: 'APAC Virtual Summit 2020'
 image: "images/events/apac2020.jpg"
 date: 2020-12-03
+youtubeLink: https://www.youtube.com/watch?v=TA82AFyIaUA&list=PLCH-i0B0otNSA4KltJHgcQB6450VI-8pG
 ---
 
 ### 2nd and 3rd December 2020, online - [event site](https://eventyay.com/e/3dbaaa50)!

--- a/content/events/isc-fall-2020.md
+++ b/content/events/isc-fall-2020.md
@@ -4,8 +4,9 @@ title: 'North American Fall Virtual Summit 2020'
 image: "images/events/america2020.jpg"
 # post type (regular/featured)
 date: 2020-09-15T00:00:00+00:00
+youtubeLink: https://www.youtube.com/watch?v=0YzOz94cNec&list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy
 ---
-### 15th and 16th September 2020, online! 
+### 15th and 16th September 2020, online!
 
 The 11th InnerSource Commons Summit stayed online thanks to the success of the <a href="https://www.youtube.com/playlist?list=PLCH-i0B0otNQeYBH5QvNRBDA3CMrS9lL9">ISC Online Spring Summit 2020</a>. You can now enjoy watching the talks on our Youtube Channel in the <a href="https://www.youtube.com/watch?v=0YzOz94cNec&list=PLCH-i0B0otNQZQt_QzGR9Il_kE4C6cQRy">InnerSource Commons Online Fall Summit 2020</a> Playlist.  
 
@@ -17,22 +18,22 @@ We continue to explore new ways to get together and keep advancing in the body o
 
 ### Summit News
 
-We are delighted to announce that **Tim O'Reilly** (Founder, CEO, and Chairman of O'Reilly Media) has been confirmed as a keynote speaker for this summit. 
+We are delighted to announce that **Tim O'Reilly** (Founder, CEO, and Chairman of O'Reilly Media) has been confirmed as a keynote speaker for this summit.
 
-Tim will join **Danese Cooper** (VP of Special Initiatives at NearForm), **James McLeod** (Director of Community at FINOS, the Fintech Open Source Foundation), **Martin Woodward** (Director of Developer Relations at GitHub), and **Silona Bonewald** (Executive Director at IEEE SA Open) in the keynote sessions. 
+Tim will join **Danese Cooper** (VP of Special Initiatives at NearForm), **James McLeod** (Director of Community at FINOS, the Fintech Open Source Foundation), **Martin Woodward** (Director of Developer Relations at GitHub), and **Silona Bonewald** (Executive Director at IEEE SA Open) in the keynote sessions.
 
 ### About the Event
 
-The summit consists of two days, each a 3.5 hour slot: running from noon East Coast US / 9 am West Coast US / 6pm Europe / 5pm UK & Ireland / 9:30pm Mumbai / midnight Singapore & Bejing (4pm UTC). 
+The summit consists of two days, each a 3.5 hour slot: running from noon East Coast US / 9 am West Coast US / 6pm Europe / 5pm UK & Ireland / 9:30pm Mumbai / midnight Singapore & Bejing (4pm UTC).
 
-We are a global community, but because our Fall Summit usually takes place in North America, it will take place slightly later than our Spring Summit (traditionally EU). 
+We are a global community, but because our Fall Summit usually takes place in North America, it will take place slightly later than our Spring Summit (traditionally EU).
 
 We are hoping to host an online summit later in the year to fit with the timezones of the growing number of Asian community participants.   
 
 
 ### Notes
 
-The following agenda is based in **Pacific Time** and this will take place between 9:00 am and 12:30 pm (3.5 hours in total). Both days, 15th and 16th of September will use the timeslot. 
+The following agenda is based in **Pacific Time** and this will take place between 9:00 am and 12:30 pm (3.5 hours in total). Both days, 15th and 16th of September will use the timeslot.
 
 Example of time differences in other timezones for the first day of conference:
 * Eastern Time: 12:00 pm - 3:30 pm 15th September
@@ -79,7 +80,7 @@ Example of time differences in other timezones for the first day of conference:
 
   <tr>
         <td class="time"> 09:50 - 10:05</td>
-	<td class="author"> <b><a href="#russ_rutledge">Russ Rutledge</a></b> (Nike) 
+	<td class="author"> <b><a href="#russ_rutledge">Russ Rutledge</a></b> (Nike)
 	</td>
         <td class="title"> InnerSource Culture Change at Scale
             <span onClick="toggleAbstract('rutledge')" class="abstract-toggle">(<a id="rutledge-link">Show Abstract</a>)</span>
@@ -93,7 +94,7 @@ InnerSource is more than telling someone the mechanics of code and community man
 
   <tr>
         <td class="time"> 10:05 - 10:20</td>
-	<td class="author"> <b><a href="#brittany_istenes">Brittany Erica Istenes</a></b> (Comcast) 
+	<td class="author"> <b><a href="#brittany_istenes">Brittany Erica Istenes</a></b> (Comcast)
         </td>
         <td class="title"> InnerSource is established, now what?
             <span onClick="toggleAbstract('istenes')" class="abstract-toggle">(<a id="istenes-link">Show Abstract</a>)</span>
@@ -136,7 +137,7 @@ The goal of my talk is to walk through how at the last summit we talked about cu
 
   <tr>
         <td class="time"> 11:25 - 11:35</td>
-	<td class="author"> <b><a href="#sebastian_spier">Sebastian Spier</a></b> (Meltwater) 
+	<td class="author"> <b><a href="#sebastian_spier">Sebastian Spier</a></b> (Meltwater)
         </td>
         <td class="title"> 1 year in the InnerSource Commons community: Getting your money's worth.
             <span onClick="toggleAbstract('spier')" class="abstract-toggle">(<a id="spier-link">Show Abstract</a>)</span>
@@ -183,7 +184,7 @@ What good is source code sitting a repo? No much, might as well be ideas on the 
 
   <tr>
         <td class="time">12:05 - 12:25</td>
-	<td class="author"> <b><a href="#martin_woodward">Martin Woodward</a></b> (GitHub) 
+	<td class="author"> <b><a href="#martin_woodward">Martin Woodward</a></b> (GitHub)
         </td>
         <td class="title"> The Top 5 Myths of InnerSource
             <span class="keynoteTag"> Keynote </span>
@@ -362,7 +363,7 @@ A seismic shift has occurred across open source ecosystems that has given rise t
 
 [Click here to register](https://www.eventbrite.ie/e/innersource-commons-fall-2020-virtual-summit-tickets-117435975163) for the InnerSource Commons Fall 2020 Virtual Summit. Ticket price is $35, inclusive of all taxes. Ticket price also includes a T-shirt to celebrate the event, which we will be send out afterwards.
 
-If, for any reason, you find the associated fee prohibits you from attending - please email us at <summit@innersourcecommons.org>, as we have a number of complementary tickets we can allocate. 
+If, for any reason, you find the associated fee prohibits you from attending - please email us at <summit@innersourcecommons.org>, as we have a number of complementary tickets we can allocate.
 
 ### Call For Presentations
 
@@ -375,11 +376,11 @@ We invite interested organisations and companies to sponsor this renowned event.
 ### What is the InnerSource Commons?
 
 The InnerSource Commons ([InnerSourceCommons.org](http://innersourcecommons.org)) aka ISC is a consortium of representatives from almost a hundred companies and institutions. It utilizes open source methods to provide organizations pursuing inner sourcing a forum for discussing and improving the practice of InnerSource through the sharing of experiences (under the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule)), creation and review of InnerSource patterns, and the open exchange of ideas.
-  
+
 ### Who should attend?
 
 The InnerSource Common Summits welcomes software professionals at all levels, from executive level manager to software developer.  The program targets software development managers and executive managers in particular because adopting InnerSource requires significant efforts to make changes in the organization—whether these are implemented top-down or bottom-up. If you or your organization is adopting, or considering adopting, InnerSource, then attending the InnerSource Summit is the best thing you can do.
-   
+
 ### What will I get from this event?
 
 The three key reasons to attend the InnerSource Common Summits are:
@@ -455,7 +456,7 @@ Martin Woodward is the Director of Developer Relations for GitHub. Before that M
 
 **Joe Chavez**
 
-Joe Chavez is a technologist with a deep background in software architecture, design, development and operations. Currently Joe is focused on digital transformation of California's Medi-Cal information technology infrastructure and applications. Leveraging and creating open source software is an integral part of this work. In the past, Joe has helped launch and operate a space telescope for NASA, built enterprise class software, and launched several mobile and IoT startups. 
+Joe Chavez is a technologist with a deep background in software architecture, design, development and operations. Currently Joe is focused on digital transformation of California's Medi-Cal information technology infrastructure and applications. Leveraging and creating open source software is an integral part of this work. In the past, Joe has helped launch and operate a space telescope for NASA, built enterprise class software, and launched several mobile and IoT startups.
 
 </div><div class="clearfix">
 <img alt="Alex Chittock photo" src="/images/events/speakers/alex-chittock.jpeg" width="200" class="speaker-photo" id="alex_chittock" />
@@ -469,7 +470,7 @@ Alex works for Lloyds Banking Group. In Alex's words: "Code has always been part
 
 **Clare Dillon**
 
-Clare Dillon has spent over 20 years working with developers and developer communities. Clare has been involved with InnerSource Commons since early 2019, when she helped set up NearForm's InnerSource practice with Danese Cooper. Before that, Clare was a member of Microsoft Ireland Leadership Team, heading up their Developer Evangelism and Experience Group. Clare also works with Moss Labs to support the establishment of University and Government Open Source Program Offices and OSPOs++ globally, that can collaborate to implement public policy and trustworthy public services. Clare frequently speaks at international conferences and corporate events on topics relating to the future of work, innovation trends and digital ethics. 
+Clare Dillon has spent over 20 years working with developers and developer communities. Clare has been involved with InnerSource Commons since early 2019, when she helped set up NearForm's InnerSource practice with Danese Cooper. Before that, Clare was a member of Microsoft Ireland Leadership Team, heading up their Developer Evangelism and Experience Group. Clare also works with Moss Labs to support the establishment of University and Government Open Source Program Offices and OSPOs++ globally, that can collaborate to implement public policy and trustworthy public services. Clare frequently speaks at international conferences and corporate events on topics relating to the future of work, innovation trends and digital ethics.
 
 </div><div class="clearfix">
 <img alt="Isabel Drost-Fromm photo" src="/images/events/speakers/isabel_drost-fromm.jpeg" width="200" class="speaker-photo" id="isabel_drost_fromm" />
@@ -483,23 +484,23 @@ Isabel Drost-Fromm is Open Source Strategist at Europace AG Germany. She's a mem
 
 **Michael Graf**
 
-Michael is software developer at SAP and Open Source enthusiast. He loves evangelizing technology, sharing knowledge, and collaborating with the community. 
+Michael is software developer at SAP and Open Source enthusiast. He loves evangelizing technology, sharing knowledge, and collaborating with the community.
 
 </div><div class="clearfix">
 <img alt="Russell Green photo" src="/images/events/speakers/russell-green.jpg" width="200" class="speaker-photo" id="russell_green" />
 
 **Russell Green**
 
-Russell currently leads Deutsche Bank’s (DB) Group Architecture function, where he is responsible for ensuring that the bank’s architecture practice is comprehensive, operational and efficient. 
+Russell currently leads Deutsche Bank’s (DB) Group Architecture function, where he is responsible for ensuring that the bank’s architecture practice is comprehensive, operational and efficient.
  
 This includes co-ordinating the group-wide architecture roadmap, ensuring an effective governance process for programmes and technology and developing the architecture foundations that underpin the strategy. Group Architecture also plays a central role in articulating the current technology landscape and measuring progress towards DB’s target state.
  
-Russell chairs a number of key forums that define the future direction of DB’s IT practice. These include the Global CTO Council, which oversees the operational and future state of DBs architecture practice; the Technology Architecture Council (TAC), which controls the organisation’s technology portfolio and the Open Source Review Council, which oversees the bank’s engagement with the global open source community. 
+Russell chairs a number of key forums that define the future direction of DB’s IT practice. These include the Global CTO Council, which oversees the operational and future state of DBs architecture practice; the Technology Architecture Council (TAC), which controls the organisation’s technology portfolio and the Open Source Review Council, which oversees the bank’s engagement with the global open source community.
  
-Russell joined DB in 2015 as CTO for the Control Functions, where he established the architecture control practice and led work to define the target state. 
-Prior to DB, he has spent over 15 years in various architecture roles across the banking sector including LCH, UBS, Barclays and most recently RBC. Before moving into financial services, Russell developed high performance billing applications for the telecoms industry. 
+Russell joined DB in 2015 as CTO for the Control Functions, where he established the architecture control practice and led work to define the target state.
+Prior to DB, he has spent over 15 years in various architecture roles across the banking sector including LCH, UBS, Barclays and most recently RBC. Before moving into financial services, Russell developed high performance billing applications for the telecoms industry.
  
-Russell attained his PhD from Imperial College in 1994 and this expertise forms the basis of his analytical approach to architecture and knowledge management. He believes that the establishment of a world class architecture function is needed to enable global organisations such as DB to execute in a coordinated and efficient manner.  
+Russell attained his PhD from Imperial College in 1994 and this expertise forms the basis of his analytical approach to architecture and knowledge management. He believes that the establishment of a world class architecture function is needed to enable global organisations such as DB to execute in a coordinated and efficient manner. 
 
 </div><div class="clearfix">
 <img alt="Georg Gruetter photo" src="/images/events/speakers/Georg Gruetter.jpg" width="200" class="speaker-photo" id="georg_grutter" />
@@ -513,16 +514,16 @@ Georg Grütter is a social coding evangelist and developer advocate at Bosch.IO.
 
 **Brittany Erica Istenes**
 
-Brittany started off her career as an elementary/special education school teacher in a lower income area of Philadelphia. 
-Seeing the need for a stronger technology presence in education, she transitioned from the classroom for a company that 
-specialized in getting students from lower income areas all across the country to read at or above grade level through 
-teaching teachers all across the country how to use online tools that track and assist getting students to meet their goals. 
-Now at Comcast, one of her main focuses is the delivery of OSS through the company and beyond as well as a a sharp focus on Community. 
-She guides the Open Source Advisory Council which is comprised of compliance lawyers, patent/strategic IP lawyers, engineers and security to 
-evaluate all Open Source contributions and new projects that come through the company. Some other projects she works on is the 
-Open Source Ambassador program which takes technologists from all over the company and guides them through the OSS process to become 
-evangels for what we do within and outside of the company. Another is the Open Source Fellowship program which focuses on getting developers 
-to dedicate 25% of their year on Open Source Software tooling.  Finally Brittany sits on the newly formed internal InnerSource Guild which guides 
+Brittany started off her career as an elementary/special education school teacher in a lower income area of Philadelphia.
+Seeing the need for a stronger technology presence in education, she transitioned from the classroom for a company that
+specialized in getting students from lower income areas all across the country to read at or above grade level through
+teaching teachers all across the country how to use online tools that track and assist getting students to meet their goals.
+Now at Comcast, one of her main focuses is the delivery of OSS through the company and beyond as well as a a sharp focus on Community.
+She guides the Open Source Advisory Council which is comprised of compliance lawyers, patent/strategic IP lawyers, engineers and security to
+evaluate all Open Source contributions and new projects that come through the company. Some other projects she works on is the
+Open Source Ambassador program which takes technologists from all over the company and guides them through the OSS process to become
+evangels for what we do within and outside of the company. Another is the Open Source Fellowship program which focuses on getting developers
+to dedicate 25% of their year on Open Source Software tooling.  Finally Brittany sits on the newly formed internal InnerSource Guild which guides
 teams through best InnerSource practices.
 
 </div><div class="clearfix">
@@ -564,7 +565,7 @@ Strategic Architect at GitHub for the past 5 years, Vitor has a computer science
 
 Diane Mueller leads Community Development at Red Hat for the Cloud Platform Group focusing on OpenShift and Cloud Native ecosystem. She is the driving force behind both customer, partner and developer community initiatives helping to ensure the success of OpenShift, the world's leading Open Source Platform as a Service along with Operators, ServiceMesh, Quay, OKD, OpenStack and other Cloud Native technology initiatives at Red Hat for the past 8 years.
 
-She has been designing and implementing products and applications embedded into mission critical financial and manufacturing systems at F500 corporations for over 30 years. She has had a long career in software development spanning multiple industries and open source initiatives from Financial Services, Manufacturing, Education and Government. 
+She has been designing and implementing products and applications embedded into mission critical financial and manufacturing systems at F500 corporations for over 30 years. She has had a long career in software development spanning multiple industries and open source initiatives from Financial Services, Manufacturing, Education and Government.
 
 </div><div class="clearfix">
 <img alt="Russ Rutledge photo" src="/images/events/speakers/russ-rutledge.jpeg" width="200" class="speaker-photo" id="russ_rutledge" />
@@ -598,7 +599,7 @@ The summit is hosted online. Instructions will be provided to all speakers and a
 
 ### [Code of Conduct](/events/conduct/)
 
-All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/). 
+All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/).
 
 All related conversations in the InnerSource Slack Channel will still be considered to fall under [Chatham House Rules](https://en.wikipedia.org/wiki/Chatham_House_Rule): information discussed can be shared but not attributed.
 

--- a/content/events/isc-spring-2018.md
+++ b/content/events/isc-spring-2018.md
@@ -4,13 +4,14 @@ title: 'Spring Summit 2018'
 image: "images/events/cities/stuttgart.jpeg"
 # post type (regular/featured)
 date: 2018-05-16T00:00:00+00:00
+youtubeLink: https://www.youtube.com/watch?v=4fgFpl-e6Vs&list=PLCH-i0B0otNT6m6EUu2ZDFyEuXXI5JkUK
 ---
 ### May 16-18 Wed-Fri near Stuttgart, Germany
 
 ### Pictures and Videos
 
 The ISC.S6 is a wrap! Thanks to all attendees for making this summit such an
-engaging and interesting one! 
+engaging and interesting one!
 
 <img alt="ISC.S6 Crowd" width="600" src="/images/events/spring2018.jpg"/>
 
@@ -18,7 +19,7 @@ We have published the first videos on the InnerSource Commons YouTube channel:
 
 [ISC.S6 Videos](https://www.youtube.com/playlist?list=PLCH-i0B0otNT6m6EUu2ZDFyEuXXI5JkUK)
 
-The authors of these videos have released them for sharing under the 
+The authors of these videos have released them for sharing under the
 Creative Commons license (CC BY).
 
 ### Agenda and speakers
@@ -43,7 +44,7 @@ Creative Commons license (CC BY).
                 <span onClick="toggleAbstract('keynote-ferber')" class="abstract-toggle">(<a id="keynote-ferber-link">Show Abstract</a>)</span>
             </span>
             <div style="display:none" class="abstract" id="keynote-ferber">
-Today, we know that InnerSource is a great way to efficiently develop software by leveraging communities that transcend organizational and geographical boundaries aka silos. We also know now, that InnerSource is an excellent segway into true Open Source development for companies lacking a software DNA. Back when Bosch started with InnerSource, there was not enough technical, legal, collaboration, social, and commercial experience within Bosch to start open source right away. Getting an InnerSource initiative off the ground in such a setting is challenging. Stefan will go back to the origins of InnerSource at Bosch and share the surprising story of how he managed convince upper management to engage in InnerSource using rather unconventional means. This included three key elements: 
+Today, we know that InnerSource is a great way to efficiently develop software by leveraging communities that transcend organizational and geographical boundaries aka silos. We also know now, that InnerSource is an excellent segway into true Open Source development for companies lacking a software DNA. Back when Bosch started with InnerSource, there was not enough technical, legal, collaboration, social, and commercial experience within Bosch to start open source right away. Getting an InnerSource initiative off the ground in such a setting is challenging. Stefan will go back to the origins of InnerSource at Bosch and share the surprising story of how he managed convince upper management to engage in InnerSource using rather unconventional means. This included three key elements:
 <ol>
 <li>start with InnerSource first and not with open source right away,</li>
 <li>start with tooling (here Eclipse IDE for automotive) and not with the Bosch products and</li>
@@ -125,9 +126,9 @@ Wayfair has a sizable (over 1200 people) engineering organization. It's comprise
         <td class="title">Prototyping in Bosch Internal Open Source
             <span onClick="toggleAbstract('dais-1')" class="abstract-toggle">(<a id="dais-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="dais-1">
-Innersource has a very positive influence on prototyping and predevelopment. A company with many products in different domains can trigger cross domain solutions by internally publishing of APIs and libraries. Sharing these within the company has been enabling reuse in different Business Units leading to surprising synergies across different applications. 
+Innersource has a very positive influence on prototyping and predevelopment. A company with many products in different domains can trigger cross domain solutions by internally publishing of APIs and libraries. Sharing these within the company has been enabling reuse in different Business Units leading to surprising synergies across different applications.
             </div>
-        </td> 
+        </td>
     </tr>
     <tr >
         <td class="author"><a href="/events/isc-spring-2018-speakers#kristof_van_tomme">Kristof Van Tomme <span class="affiliation">(Pronovix)</span></td>
@@ -437,7 +438,7 @@ Everybody can install a software forge, prescribe that "we are doing inner sourc
         <td class="title">An Oriole for InnerSource
             <span onClick="toggleAbstract('rutledge-2')" class="abstract-toggle">(<a id="rutledge-2-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="rutledge-2">
-Inner source is the application of open source methodologies to internally-developed software.  While simple to define, inner source can be difficult to explain and implement successfully.  This presentation introduces the key terms, concepts, and principles for effective inner sourcing along with explanations and real examples.  It is content that is accessible to newcomers while at the same time refreshing to those with experience. The same information in this presentation is also delivered as an O’Reilly Oriole, available freely at https://www.safaribooksonline.com/oriole/.  We’ll review the Oriole, how to use it, and other Orioles related to inner source that are on the way. 
+Inner source is the application of open source methodologies to internally-developed software.  While simple to define, inner source can be difficult to explain and implement successfully.  This presentation introduces the key terms, concepts, and principles for effective inner sourcing along with explanations and real examples.  It is content that is accessible to newcomers while at the same time refreshing to those with experience. The same information in this presentation is also delivered as an O’Reilly Oriole, available freely at https://www.safaribooksonline.com/oriole/.  We’ll review the Oriole, how to use it, and other Orioles related to inner source that are on the way.
             </div>
         </td>
     </tr>
@@ -465,7 +466,7 @@ Dr. Ferber holds an undergraduate degree and a Ph.D. in computer science from th
 <p>
 Today, we know that InnerSource is a great way to efficiently develop software by leveraging communities that transcend organizational and geographical boundaries aka silos. We also know now, that InnerSource is an excellent segway into true Open Source development for companies lacking a software DNA. Back when Bosch started with InnerSource, there was not enough technical, legal, collaboration, social, and commercial experience within Bosch to start open source right away.  
 
-Getting an InnerSource initiative off the ground in such a setting is challenging. Stefan will go back to the origins of InnerSource at Bosch and share the surprising story of how he managed convince upper management to engage in InnerSource using rather unconventional means.  This included three key elements: 
+Getting an InnerSource initiative off the ground in such a setting is challenging. Stefan will go back to the origins of InnerSource at Bosch and share the surprising story of how he managed convince upper management to engage in InnerSource using rather unconventional means.  This included three key elements:
 
 <ol>
 <li>start with InnerSource first and not with open source right away, </li>
@@ -557,7 +558,7 @@ Having in total 16 years’ of experience in the telecommunications industry spe
 
 **Erin Bank**
 
-Erin Bank has 20 years of experience in engineering program management and technical communications in North America and abroad. Erin is an Advisor of Engineering Program Management for the CA Technologies Office of the CTO, where she built and currently drives the Inner Source program for CA Product Development. Erin also drives strategic transformation for the CA Accelerator program, where internal innovators receive support and funding to get new products into market. She is a contributing member of InnerSource Commons, committed to establishing inner source best practices with the community. Erin is also an elected member of the CA Council for Technical Excellence, and has Lean Six Sigma and Pragmatic certification. 
+Erin Bank has 20 years of experience in engineering program management and technical communications in North America and abroad. Erin is an Advisor of Engineering Program Management for the CA Technologies Office of the CTO, where she built and currently drives the Inner Source program for CA Product Development. Erin also drives strategic transformation for the CA Accelerator program, where internal innovators receive support and funding to get new products into market. She is a contributing member of InnerSource Commons, committed to establishing inner source best practices with the community. Erin is also an elected member of the CA Council for Technical Excellence, and has Lean Six Sigma and Pragmatic certification.
 
 </div>
 
@@ -721,9 +722,9 @@ I am a development manager of a technology foundations group at Amdocs, developi
 
 **Russ Rutledge**
 
-Russ Rutledge is the lead of Nike's Community Core team.  This startup within Nike culls the process and tools to encourage and foster cross-team and community interaction and development.  His drive and passion is to enable all software engineers to achieve incredible technical and business throughput via quality tooling and streamlined work process. 
+Russ Rutledge is the lead of Nike's Community Core team.  This startup within Nike culls the process and tools to encourage and foster cross-team and community interaction and development.  His drive and passion is to enable all software engineers to achieve incredible technical and business throughput via quality tooling and streamlined work process.
 
-Prior to this role Russ ran another successful startup delivering JavaScript continuous delivery solutions to hundreds of projects throughout Nike via inner source principles.  Previous experience includes feature and infrastructure development at Microsoft on the Outlook and OneDrive consumer web sites. 
+Prior to this role Russ ran another successful startup delivering JavaScript continuous delivery solutions to hundreds of projects throughout Nike via inner source principles.  Previous experience includes feature and infrastructure development at Microsoft on the Outlook and OneDrive consumer web sites.
 
 </div>
 
@@ -732,7 +733,7 @@ Prior to this role Russ ran another successful startup delivering JavaScript con
 
 **Klaas-Jan Stol**
 
-Dr. Klaas-Jan Stol is a Lecturer with the School of Computer Science and Technology at University College Cork. Previously he worked as a Research Fellow with Lero—the Irish Software Research Centre. He holds a PhD in software engineering from the University of Limerick on Open and InnerSource. He conducts research on contemporary software development methods and strategies, including InnerSource, Open Source, crowdsourcing, and agile and lean methods. His work on InnerSource has been published in several top journals and magazines including ACM Transactions on Software Engineering and Methodology and IEEE Transactions on Software Engineering. In a previous life, he was a contributor to the Perl 6 open source project. 
+Dr. Klaas-Jan Stol is a Lecturer with the School of Computer Science and Technology at University College Cork. Previously he worked as a Research Fellow with Lero—the Irish Software Research Centre. He holds a PhD in software engineering from the University of Limerick on Open and InnerSource. He conducts research on contemporary software development methods and strategies, including InnerSource, Open Source, crowdsourcing, and agile and lean methods. His work on InnerSource has been published in several top journals and magazines including ACM Transactions on Software Engineering and Methodology and IEEE Transactions on Software Engineering. In a previous life, he was a contributor to the Perl 6 open source project.
 
 </div>
 
@@ -759,15 +760,15 @@ Tim is a Distinguished Member of Technical Staff and a Portfolio Manager in  Nok
 ### What is InnerSource?
 
 InnerSource takes the lessons learned from developing open source software and applies them to the way companies develop software internally. As developers have become accustomed to working on world class open source software, there is a strong desire to bring those practices back inside the firewall and apply them to software that companies may be reluctant to release. For companies building mostly closed source software, InnerSource can be a great tool to help break down silos, encourage internal collaboration, accelerate new engineer on-boarding, and identify opportunities to contribute software back to the open source world.
- 
+
 ### What is the InnerSource Commons?
 
 The InnerSource Commons ([InnerSourceCommons.org](http://innersourcecommons.org)) aka ISC is a consortium of representatives from over sixty companies and institutions. It utilizes open source methods to provide organizations pursuing inner sourcing a forum for discussing and improving the practice of InnerSource through the sharing of experiences (under the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule)), creation and review of InnerSource patterns, and the open exchange of ideas.
-  
+
 ### Who should attend?
 
 The InnerSource Common Summits welcomes software professionals at all levels, from executive level manager to software developer.  The program targets software development managers and executive managers in particular because adopting InnerSource requires significant efforts to make changes in the organization—whether these are implemented top-down or bottom-up. If you or your organization is adopting, or considering adopting, InnerSource, then attending the InnerSource Summit is the best thing you can do.
-   
+
 ### What will I get from this event?
 
 The three key reasons to attend the InnerSource Common Summits are:
@@ -789,7 +790,7 @@ Germany<br/>
 
 ### Food
 
-Morning snack, lunch and afternoon snack will be provided to Summit attendees each day, courtesy of Robert Bosch. 
+Morning snack, lunch and afternoon snack will be provided to Summit attendees each day, courtesy of Robert Bosch.
 
 ### Evening Events
 
@@ -798,7 +799,7 @@ Morning snack, lunch and afternoon snack will be provided to Summit attendees ea
 
 ### [Code of Conduct](/events/conduct/)
 
-All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/). 
+All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/).
 
 InnerSource Commons meetings run under the [Chatham House Rule](https://en.wikipedia.org/wiki/Chatham_House_Rule): information discussed at a meeting can be shared but not attributed.
 

--- a/content/events/isc-spring-2020.md
+++ b/content/events/isc-spring-2020.md
@@ -4,6 +4,7 @@ title: 'Spring Summit 2020'
 image: "images/events/cities/madrid.jpeg"
 # post type (regular/featured)
 date: 2020-04-14
+youtubeLink: https://www.youtube.com/watch?v=glYcE3CEELI&list=PLCH-i0B0otNQeYBH5QvNRBDA3CMrS9lL9
 ---
 ### 14th to 15th April 2020, online
 
@@ -17,7 +18,7 @@ These two days will be a three hours slot taking place from 4 pm CET till 7 pm C
 
 The day will be split as a sandwich, where talks will be the bread and discussions the _yummi yummi_ part. We are expecting to have two keynotes per day (up to 25 minutes each), and four lightning talks (up to 15 minutes each). These will be initially pre-recorded and discussions will take place in the InnerSource Commons Slack. Right in the middle we will have a break and two breakout sessions with live interactions.
 
-We're planning to have a contest as well as icebreaker during the first moments of this, do not miss this! 
+We're planning to have a contest as well as icebreaker during the first moments of this, do not miss this!
 
 ### COVID-19 and InnerSource Commons current Status
 
@@ -70,7 +71,7 @@ Example of time differences in other timezones for the first day of conference:
             <span class="keynoteTag">Keynote: </span>
             <span onClick="toggleAbstract('keynote-danese')" class="abstract-toggle">(<a id="keynote-danese-link">Show Abstract</a>)</span>
         <div style="display:none" class="abstract" id="keynote-danese">
-Details appearing shortly 
+Details appearing shortly
         </div>
         </td>
   </tr>
@@ -84,13 +85,13 @@ Details appearing shortly
 	<td class="title"><a href="https://youtu.be/2nhKMcv5STc">Growing an InnerSource culture at SAP</a>
             <span onClick="toggleAbstract('graf-1')" class="abstract-toggle">(<a id="graf-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="graf-1">
-In a multinational software corporation like SAP, that has recently grown to almost a hundred thousand employees, reuse and efficient collaboration across organizational borders is quite a challenge. Our development organization spreads across the globe and our products are implemented on a large variety of technology stacks. How can we establish an efficient development process and a collaboration culture at the same time? 
+In a multinational software corporation like SAP, that has recently grown to almost a hundred thousand employees, reuse and efficient collaboration across organizational borders is quite a challenge. Our development organization spreads across the globe and our products are implemented on a large variety of technology stacks. How can we establish an efficient development process and a collaboration culture at the same time?
 
 As we transform into a cloud company, we leverage open standards and open source components in our products. We also create technology frameworks and tools that we share with the community. Also, we are a strong and diverse community of developers inside the company. Collaboration happens quite naturally because we identify synergies or have a similar challenge to solve – sometimes without knowing that we are doing InnerSource.
 
-On larger scale, InnerSource establishes well-aligned architectures, maximizes reuse, and avoids organizational silos. It allows to share not only code, but also architectural patterns, data models, learning material, knowledge and experiences, as well as documentation across organizational borders. And it can also be an incubator for open source. Therefore, it is important to promote and facilitate the adoption of InnerSource across the company. 
+On larger scale, InnerSource establishes well-aligned architectures, maximizes reuse, and avoids organizational silos. It allows to share not only code, but also architectural patterns, data models, learning material, knowledge and experiences, as well as documentation across organizational borders. And it can also be an incubator for open source. Therefore, it is important to promote and facilitate the adoption of InnerSource across the company.
 
-Along practical examples, we share our journey towards InnerSource and how we are growing a collaboration culture based on open source methodology in our development organization. 
+Along practical examples, we share our journey towards InnerSource and how we are growing a collaboration culture based on open source methodology in our development organization.
             </div>
         </td>
     </tr>
@@ -145,11 +146,11 @@ The modern IT consists of constant transformations, product and feature teams, a
            <a href="/events/isc-spring-2020-speakers#katrina_novakovic">Katrina Novakovic</a> <span class="affiliation"> (Red Hat)</span></td>
         <td class="title"><a href="https://youtu.be/1T5llwc2XQQ">
 		Does your organisation need to change its culture to improve Inner Source adoption? </a>
-            <span onClick="toggleAbstract('novakovic-1')" class="abstract-toggle">(<a id="novakovic-1-link">Show Abstract</a>)</span> 
+            <span onClick="toggleAbstract('novakovic-1')" class="abstract-toggle">(<a id="novakovic-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="novakovic-1">
 In this talk, we'll explore topics crucial to Inner Source culture, including:
-    (a) whether your organisation's current cultural values and established beliefs are a good fit for the ways of working required for Inner Source; 
-    (b) how to get more employees to collaborate on Inner Source projects that are not part of their specific responsibility; 
+    (a) whether your organisation's current cultural values and established beliefs are a good fit for the ways of working required for Inner Source;
+    (b) how to get more employees to collaborate on Inner Source projects that are not part of their specific responsibility;
     (c) using perceived negative cultural traits such as competitiveness and control to your advantage.
 
 This session offers an opportunity to participate in the conversation by asking your own questions about Inner Source culture, sharing insights and experiences, hearing what's worked well for other organisations, and getting to know others in Inner Source. Dive in and join the conversation, or just sit back, observe, and listen.
@@ -179,7 +180,7 @@ During the breakout groups following this talk, we are certain you can apply you
             <span class="keynoteTag">Keynote:</span>
             <span onClick="toggleAbstract('keynote-ruff')" class="abstract-toggle">(<a id="keynote-ruff-link">Show Abstract</a>)</span>
         <div style="display:none" class="abstract" id="keynote-ruff">
-Details appearing shortly 
+Details appearing shortly
         </div>
         </td>
   </tr>
@@ -219,7 +220,7 @@ Details appearing shortly
             <span class="keynoteTag">Keynote:</span>
             <span onClick="toggleAbstract('keynote-drost-1')" class="abstract-toggle">(<a id="keynote-drost-1-link">Show Abstract</a>)</span>
             <div style="display:none" class="abstract" id="keynote-drost-1">
-Details appearing shortly 
+Details appearing shortly
             </div>
         </td>
     </tr>
@@ -370,7 +371,7 @@ Georg Grütter is a social coding evangelist and developer advocate at Bosch.IO.
 
 **Nithya Ruff**
 
-Nithya A. Ruff is the Head of Comcast’s Open Source Program Office.  She is responsible for growing Open Source culture inside of Comcast and engagement with external communities. Prior to this, she started and grew Western Digital’s Open Source Strategy Office. She first glimpsed the power of open source while at SGI in the 90s and has been building bridges between companies and the open source community ever since. She’s also held leadership positions at Wind, Synopsys, Avaya, Tripwire and Eastman Kodak. At Wind, she led a team of product managers in managing a world class embedded Linux distribution and was a key member of the Yocto Project advocacy team on the board. Nithya has been director-at-large on the Linux Foundation Board for the last 3 years and was recently elected to be Chair of the Linux Foundation Board. 
+Nithya A. Ruff is the Head of Comcast’s Open Source Program Office.  She is responsible for growing Open Source culture inside of Comcast and engagement with external communities. Prior to this, she started and grew Western Digital’s Open Source Strategy Office. She first glimpsed the power of open source while at SGI in the 90s and has been building bridges between companies and the open source community ever since. She’s also held leadership positions at Wind, Synopsys, Avaya, Tripwire and Eastman Kodak. At Wind, she led a team of product managers in managing a world class embedded Linux distribution and was a key member of the Yocto Project advocacy team on the board. Nithya has been director-at-large on the Linux Foundation Board for the last 3 years and was recently elected to be Chair of the Linux Foundation Board.
 
 Nithya has been a passionate advocate and a speaker for opening doors to new people in Open Source for many years. She has also been a promoter of valuing diverse ways of contributing to open source such as in marketing, legal and community.   You can often find her on social media promoting dialogue on diversity and open source.
 
@@ -433,7 +434,7 @@ Tom Sadler is a Software Engineering Team Lead for BBC iPlayer, specialising in 
 
 **Dmitrii Sugrobov**
 
-Dmitrii is a software engineer, DevOps believer, evangelist at Leroy Merlin. Leroy Merlin is a DIY retail company that is part of the Adeo group with a presence in 15 countries. InnerSource is one of the key directions in software development across all business units of the company. 
+Dmitrii is a software engineer, DevOps believer, evangelist at Leroy Merlin. Leroy Merlin is a DIY retail company that is part of the Adeo group with a presence in 15 countries. InnerSource is one of the key directions in software development across all business units of the company.
 Dmitrii improves the processes associated with the life of the code during and after its being crafted. Believes that the time of lone programmers is long gone. Speaker of various conferences across Russia and France.
 
 </div><div class="clearfix">
@@ -448,7 +449,7 @@ OSPO of Baidu.Inc, over 20 years working experience with OSS, committer of Mozil
 
 **Johannes Tigges**
 
-Johannes is a co-creator of the InnerSource Commons Learning Path and has worked on introducing InnerSource to HERE Technologies, a leading digital map and location company. Currently he offers consulting on topics around open collaboration, automation, and everything open. Aside of that he works as lecturer and delivers technical trainings. 
+Johannes is a co-creator of the InnerSource Commons Learning Path and has worked on introducing InnerSource to HERE Technologies, a leading digital map and location company. Currently he offers consulting on topics around open collaboration, automation, and everything open. Aside of that he works as lecturer and delivers technical trainings.
 He presents his work and thoughts at industry conferences like the FOSDEM or the InnerSource Commons Summit and is active in Open Source communities since a long time. With a background in both computer science and sociology of organization he has a unique perspective on software engineering organizations.
 In past roles, he has worked on introducing Continuous Integration and Delivery to large research institutions, in DevOps roles for very large cloud based platforms and developed software within the Telco domain.
 
@@ -463,11 +464,11 @@ Kristof Van Tomme is an open source strategist and architect. He is the CEO and 
 ### What is the InnerSource Commons?
 
 The InnerSource Commons ([InnerSourceCommons.org](http://innersourcecommons.org)) aka ISC is a consortium of representatives from almost a hundred companies and institutions. It utilizes open source methods to provide organizations pursuing inner sourcing a forum for discussing and improving the practice of InnerSource through the sharing of experiences (under the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule)), creation and review of InnerSource patterns, and the open exchange of ideas.
-  
+
 ### Who should attend?
 
 The InnerSource Common Summits welcomes software professionals at all levels, from executive level manager to software developer.  The program targets software development managers and executive managers in particular because adopting InnerSource requires significant efforts to make changes in the organization—whether these are implemented top-down or bottom-up. If you or your organization is adopting, or considering adopting, InnerSource, then attending the InnerSource Summit is the best thing you can do.
-   
+
 ### What will I get from this event?
 
 The three key reasons to attend the InnerSource Common Summits are:
@@ -496,7 +497,7 @@ Call for presentations is already closed, thanks for your interest.
 
 ### [Code of Conduct](/events/conduct/)
 
-All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/). 
+All participants, vendors, and guests at InnerSource Commons events are required to abide by the [code of conduct](/events/conduct/).
 
 InnerSource Commons meetings and events run under the [Chatham House Rule](https://en.wikipedia.org/wiki/Chatham_House_Rule): information discussed at a meeting can be shared but not attributed.
 

--- a/content/events/meetup-04-2021.md
+++ b/content/events/meetup-04-2021.md
@@ -1,10 +1,11 @@
 ---
-title: InnerSource Metrics, Value & ROI Community Call 
+title: InnerSource Metrics, Value & ROI Community Call
 type: redirects
 redirect: "https://www.eventbrite.com/e/innersource-commons-community-call-metrics-value-roi-tickets-147099639983"
 image: "images/events/meetup-04-21.jpeg"
 date: 2021-03-18
 featured: false
+youtubeLink: https://www.youtube.com/watch?v=VvP4Ubet7qM&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 In this session we will be joined by Joe Patrao from Bloomberg and Daniel Izquierdo from Bitergia, who will be sharing their experiences of how to measure the success of your InnerSource implementation.

--- a/content/events/meetup-05-2021.md
+++ b/content/events/meetup-05-2021.md
@@ -1,10 +1,11 @@
 ---
-title: InnerSource in Government 
+title: InnerSource in Government
 type: redirects
 redirect: "https://www.eventbrite.com/e/innersource-commons-community-call-innersource-in-government-tickets-149394552127"
 image: "images/events/meetup-05-21.JPG"
 date: 2021-04-06
 featured: false
+youtubeLink: https://www.youtube.com/watch?v=GnT9IRAqzOo&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 In this session we will be joined by Zack Koppert from GitHub and some of the InnerSource Community, who will be sharing their experiences of how to implement InnerSource in government organizations.

--- a/content/events/meetup-06-2021.md
+++ b/content/events/meetup-06-2021.md
@@ -1,10 +1,11 @@
 ---
-title: InnerSource & DevOps 
+title: InnerSource & DevOps
 type: redirects
 redirect: "https://www.eventbrite.com/e/innersource-commons-community-call-innersource-devops-tickets-152994650117?aff=erelexpmlt"
 image: "images/events/meetup-06-21.JPG"
 date: 2021-05-05
 featured: false
+youtubeLink: https://www.youtube.com/watch?v=pEGMxe6xz-0&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 In this session we will be joined by Fei Wan from Comcast, Steph Egan from BBC and Tom Sadler from BBC who will be sharing their experiences of implementing DevOps with InnerSource.

--- a/content/events/meetup-07-2021.md
+++ b/content/events/meetup-07-2021.md
@@ -5,6 +5,7 @@ redirect: "https://www.eventbrite.com/e/innersource-commons-community-call-inner
 image: "images/events/meetup-07-21.JPG"
 date: 2021-07-06
 featured: false
+youtubeLink: https://www.youtube.com/watch?v=Yi2iVMa-gxM&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 Join us for an InnerSource Commons Community Call where we will discuss the topic of InnerSource & Discoverability with Michael Graf and Guilherme Delagustin from SAP.

--- a/content/events/meetup-09-07-2021.md
+++ b/content/events/meetup-09-07-2021.md
@@ -5,6 +5,7 @@ redirect: "https://www.eventbrite.com/e/innersource-commons-community-call-inner
 image: "images/events/meetup-09-21.JPG"
 date: 2021-09-07
 publishDate: 2020-07-06
+youtubeLink: https://www.youtube.com/watch?v=bMDRMCo7zCU&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 September 7th at 4pm GMT / 5pm CET • Online Join us for an InnerSource Commons Community Call where we will discuss the topic of InnerSource in Action with Georg Grütter from Bosch and Isabel Drost-Fromm from Europace.

--- a/content/events/meetup-09-21-2021.md
+++ b/content/events/meetup-09-21-2021.md
@@ -5,6 +5,7 @@ redirect: "https://www.eventbrite.com/e/innersource-community-call-innersource-i
 image: "images/events/meetup-21-09-21.jpeg"
 date: 2021-09-21
 publishDate: 2020-07-31
+youtubeLink: https://www.youtube.com/watch?v=8leBj-CyOfg&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 September 21st at 8am UTC / 10am CEST / 4pm CST / 6pm AEST • Online - Join us for an InnerSource Commons Community Call where we will discuss the topic of InnerSource in the Enterprise - Stories from National Australia Bank and Huawei with Matt Cobby and Willem Jiang.

--- a/content/events/meetup-10-05-2021.md
+++ b/content/events/meetup-10-05-2021.md
@@ -5,6 +5,7 @@ redirect: "https://www.eventbrite.com/e/innersource-community-call-innersource-p
 image: "images/events/meetup-10-05-2021.JPG"
 date: 2021-10-05
 publishDate: 2021-09-20
+youtubeLink: https://www.youtube.com/watch?v=nfdYQQrAK18&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 October 05th at 4pm GMT / 5pm CET • Online - Join us for an InnerSource Commons Community Call where we will discuss the topic of InnerSource Patterns with Gil Yehuda from US Bank, Fei Wan from Comcast and Sebastian Spier from Meltwater.

--- a/content/events/meetup-10-20-2021.md
+++ b/content/events/meetup-10-20-2021.md
@@ -5,6 +5,7 @@ redirect: "https://www.eventbrite.com/e/innersource-commons-strategies-for-kick-
 image: "images/events/meetup-10-20-21.JPG"
 date: 2021-10-20
 publishDate: 2021-10-07
+youtubeLink: https://www.youtube.com/watch?v=8DifoSQQRfI&list=PLCH-i0B0otNR90HDn8D9PsnQNE1r3JiUE
 ---
 
 October 20th at 8am UTC / 10am CEST / 4pm CST / 6pm AEST. • Online - Join us for an InnerSource Commons Community Call where we will discuss  Strategies to Kick-start InnerSource in enterprise organizations with Jesús Alonso Gutierrez from Grupo Santander and Shishir Saxena from Fidelity.

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -43,7 +43,7 @@
             <p class="card-text event-card-text">{{ .Summary }}</p>
             <a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-primary btn-sm">Open Event</a>
             {{ if .Params.youtubeLink }}
-              <a href="{{ .Params.youtubeLink }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-secondary btn-sm">Watch Recording</a>
+              <a href="{{ .Params.youtubeLink }}" target="_blank" class="btn btn-secondary btn-sm">Watch Recording</a>
             {{ end }}
           </div>
         </div>

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -30,7 +30,7 @@
       </div>
       {{ end }}
       <div class="container text-center pb-4 mb-4">
-        <h3 class="display-4">Past Events</h2>
+        <h3 class="display-4">Past Events</h3>
       </div>
       {{ range where $pages ".Date.Unix" "<" $yesterday }}
       <div class="col-lg-4 col-sm-6 mb-5 event-card">

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -42,6 +42,9 @@
             <h3><a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="post-title">{{ .Title }}</a></h3>
             <p class="card-text event-card-text">{{ .Summary }}</p>
             <a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-primary btn-sm">Open Event</a>
+            {{ if .Params.youtubeLink }}
+              <a href="{{ .Params.youtubeLink }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-secondary btn-sm">Watch Recording</a>
+            {{ end }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
I noticed that when I am on the Event Overview page, I cannot find the recordings of previous Community Calls there. Instead all links bring me to the event page (eventbrite etc). To find the recording, I have to go to the youtube channel and search for it there, which is cumbersome.

This PR adds a  "Watch Recording" button, next to the "Open Event" button. 
That button will only be shown when the respective event has a `youtubeLink` property in the markdown file.

Besides adding the feature itself, I also added the links to the youtube videos for all Community Calls.
(video or playlist links for other events would have to be added separately)

_Note:_
The value of `youtubeLink` could be any URL. So we could use it to point to individual videos (for Community Calls), or to youtube playlists (for Summits).

## Things to do when reviewing the PR

- [ ] double check that I linked to the correct video links for the Community Calls
- [ ] the dark background of the "Watch Recording" isn't super pretty. any idea how to make that button look better?
