### PR TITLE
InnerSource in Action - only show citation toggle if citation exists

### DIFF
--- a/content/community/action.md
+++ b/content/community/action.md
@@ -206,7 +206,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="Toshiba" image="/images/logos/toshiba.png" article="https://eventyay.com/e/3dbaaa50" >}}
       {{< /company >}}
-      {{< company name="Tray.io" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineering" >}}
+      {{< company name="Trayio" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineering" >}}
       Anyone can learn something from another team and quickly see what’s in the code..Having a fairly open structure allows people to get involved quite easily and quickly.
       {{< /company >}}
       {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -206,7 +206,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="Toshiba" image="/images/logos/toshiba.png" article="https://eventyay.com/e/3dbaaa50" >}}
       {{< /company >}}
-      {{< company name="Tray.io" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineeering" >}}
+      {{< company name="Tray.io" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineering" >}}
       Anyone can learn something from another team and quickly see what’s in the code..Having a fairly open structure allows people to get involved quite easily and quickly.
       {{< /company >}}
       {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -15,12 +15,12 @@ image: "/images/learn/innersourceinaction.png"
       {{< company name="Adobe" image="/images/logos/adobe.png" article="https://medium.com/adobetech/open-development-inner-source-and-open-source-46c2ba174be6" >}}
       {{< /company >}}
      {{< company name="Ahold Delhaize" image="/images/logos/ahold.png" article="https://github.com/customer-stories/ahold-delhaize" author_name="Joost Hofman" author_title="Head of Tech Enabling" >}}
-      If we give people the right tools and the right platform, it’s a start. We can share more within our company and with each other, growing as an InnerSource organization. 
+      If we give people the right tools and the right platform, it’s a start. We can share more within our company and with each other, growing as an InnerSource organization.
       {{< /company >}}
       {{< company name="American Airlines" image="/images/logos/americanairlines.png" article="https://soundcloud.com/nearform/the-journey-to-innersource-with-danese-cooper-spencer-kaiser" >}}
       {{< /company >}}
       {{< company name="ASOS" image="/images/logos/asos.png" article="https://medium.com/asos-techblog/adopting-innersource-at-asos-5618435c8d7" author_name="Rob Bell" author_title="Principal Software Engineer" >}}
-      InnerSource has allowed us to deliver dozens of cross-cutting features more efficiently, spanning multiple teams and services. 
+      InnerSource has allowed us to deliver dozens of cross-cutting features more efficiently, spanning multiple teams and services.
       {{< /company >}}
       {{< company name="Anyshore" image="/images/logos/Anyshore.png" article="https://www.linkedin.com/pulse/anyshore-innersource-journey-lisalee-tunde-farrell/?trackingId=2whtvdgFQga8y6CG8N9TOg%3D%3D" >}}
       {{< /company >}}
@@ -37,7 +37,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="BCG Gamma" image="/images/bcg.png" article="https://github.com/customer-stories/bcg-gamma" >}}
       {{< /company >}}
-      {{< company name="Bitergia" image="/images/logos/bitergia.png" >}} article="https://www.linkedin.com/feed/update/urn:li:activity:6711604569262067712/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6711604569262067712%29"
+      {{< company name="Bitergia" image="/images/logos/bitergia.png" article="https://www.linkedin.com/feed/update/urn:li:activity:6711604569262067712/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6711604569262067712%29" >}}
       {{< /company >}}
       {{< company name="Bloomberg" image="/images/logos/bloomberg.png" article="https://resources.github.com/whitepapers/introduction-to-innersource/" author_name="Panna Pavangadkar" author_title="Global Head of Engineering Developer Experience" >}}
       InnerSource is not new to Bloomberg … our competitive advantage is really in being able to innovate, come up with new ideas and get them out to our specialized consumers on a regular basis at the speed that they require it to be competitive in the market.

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -4,13 +4,15 @@
       <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" class="mh-150 company-logo">
     </div>
     <div class="cite-icons mt-1 align-items-center justify-content-center mb-0">
-      {{ if .Inner }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}
+      {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite" bla="{{ trim .Inner "\n " }}"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}
       {{ if .Get "video" }}<a href="{{ .Get "video" }}" target="_blank"><i class="ti-video-camera mb-0 mr-1 ml-1"></i></a>{{ end }}
       {{ if .Get "article" }}<a href="{{ .Get "article" }}" target="_blank"><i class="ti-book mb-0 ml-1"></i></a>{{ end }}
     </div>
-    <div id="{{ urlize (.Get "name")}}-cite" class="cite-text">
-    {{ with .Inner }}<p><cite>“{{ . }}”</cite></p> {{ end }}
-    {{ if .Get "author_name" }}<a href="{{ .Get "link" }}"><b>{{ .Get "author_name" }}</b>, {{ .Get "author_title" }}</a>{{ end }}
-    </div>
+    {{ if (not (eq (trim .Inner "\n ") "")) }}
+      <div id="{{ urlize (.Get "name")}}-cite" class="cite-text">
+      <p><cite>“{{ .Inner }}”</cite></p>
+      {{ if .Get "author_name" }}<a href="{{ .Get "link" }}"><b>{{ .Get "author_name" }}</b>, {{ .Get "author_title" }}</a>{{ end }}
+      </div>
+    {{ end }}
   </div>
 </div>


### PR DESCRIPTION
The [InnerSource in Action](https://innersourcecommons.org/community/action/) page shows the citation button/toggle for each company, even if we don't have a citation for that company. That leads to confusion for the reader (they think they can read a citation while they cannot) and a not so pretty looking effect (shown below).

<img width="60%" alt="citation-toggle-before" src="https://user-images.githubusercontent.com/163029/154857128-7b602f31-4713-4619-8868-c1c2cac18cae.png">

I fixed that by checking whether a citation text exists, and only rendering the citation toggle button (and associated DIV) if it does. I needed the templating function [trim](https://gohugo.io/functions/trim/) for this to get rid of the whitespace in between the `{{< company >}}` tags and to check afterwards that trimming if it contains any citation text.

With that fix applied (so if we merge this PR) the page looks like this:

<img width="60%" alt="citation-toggle-after" src="https://user-images.githubusercontent.com/163029/154857178-96669141-99af-4fbd-aab5-0b1f82af7f0c.png">

## Other fixes

I also made the following smaller fixes:

- Fixing company article link for bitergia
- [bug] removing dot (.) from company name of "Tray.io, to make the citation toggle work.
- spelling fix

## Questions

While reviewing this page I also noticed some things that look strange, where I didn't know how to fix them. I listed them as questions below.

- The citation text for Walmart and WayFair is the same (likely a bug)
- The citation fo GitHub sounds strange to me:
   - "The reason why InnerSource works is because like open source you're working with people who are collaborating with different priorities kind of thing because they're working on different things". 
   - From "kind of thing ..." onwards I don't understand what it means anymore
 