### PR TITLE
Created shortcode for about text

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -109,7 +109,7 @@ ol.breadcrumb {
 }
 
 .logo-home {
-    max-height: 200px;
+    max-height: 260px;
     float: right;
 }
 [class*=" ti-"], [class^=ti-] {

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,7 +21,7 @@ title: "InnerSource Commons"
     <div class="row align-items-center mb-3">
       <div class="col-md-9">
         <img src="/images/logo-big.png" class="img-fluid logo-home pr-5" style="float: left;">
-        <p>The InnerSource Commons is a growing community of practitioners with the goal of creating and sharing knowledge about InnerSource: the use of open source best practices for software development within the confines of an organization. Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies.
+        <p>{{< about-text >}}
         </p>
       </div>
       <div class="col-md-3">

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -12,7 +12,7 @@ draft: false
         <img src="/images/logo-big.png" class="img-fluid logo-home pr-4">
       </div>
       <div class="col-md-7">
-        <p>The InnerSource Commons is a growing community of practitioners with the goal of creating and sharing knowledge about InnerSource. Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.
+        <p>{{< about-text >}}
         </p>
         <a href="/about/announcements" class="btn-link">Announcements <i class="ti-arrow-right"></i></a>
       </div>

--- a/content/about/announcements/2020-10-ec-innersource-adoption.md
+++ b/content/about/announcements/2020-10-ec-innersource-adoption.md
@@ -11,4 +11,7 @@ The InnerSource Commons welcomes the [European Commission's new Open Source Soft
 "InnerSource is rapidly gaining momentum as a way to help developers on their path to open source. It can be a great tool to help break down silos, encourage collaboration and reuse of code, and to identify opportunities to contribute software back to the open source world. We welcome the European Commission's decision to adopt and promote InnerSource. We hope the community-created resources from the InnerSource Commons community will aid the Commission in their implementation of this strategy, and we look forward to learning from the Commission about their own best practices." said Danese Cooper, President of InnerSource Commons. 
  
 #### About InnerSource Commons
-InnerSource Commons is a growing community of InnerSource practitioners with the goal of creating and sharing knowledge about InnerSource.  The community provides free-to-use learning paths and curates known best practices in the form of patterns. They also organise the leading conferences dedicated to InnerSource, the InnerSource Commons Summits. Visit www.innersourcecommons.org to find out more.
+
+<p>
+{{< about-text >}}
+</p>

--- a/content/about/announcements/2021-03-finos.md
+++ b/content/about/announcements/2021-03-finos.md
@@ -17,4 +17,7 @@ InnerSource Commons will work with FINOS to promote and document best practices 
 "With FINOS, we look to support financial services organizations in their InnerSource journey. It can reduce bottlenecks, enable internal collaboration and innovation, accelerate new engineer on-boarding, and identify opportunities to create efficiencies within organizations," said Danese Cooper, Founder and President of InnerSource Commons. "We look forward to accomplishing great things and are excited to contribute to the open source movement that FINOS is building in financial services with leading technology-centered organizations of every stripe."
 
 #### About InnerSource Commons
-InnerSource Commons is a growing community of InnerSource practitioners with the goal of creating and sharing knowledge about InnerSource.  The community provides free-to-use learning paths and curates known best practices in the form of patterns. They also organise the leading conferences dedicated to InnerSource, the InnerSource Commons Summits. Visit www.innersourcecommons.org to find out more.
+
+<p>
+{{< about-text >}}
+</p>

--- a/content/about/announcements/2021-03-new-board.md
+++ b/content/about/announcements/2021-03-new-board.md
@@ -15,4 +15,7 @@ We would like to congratulate the new board and thank the previous members of th
 “The next 5 years are extremely important for InnerSource Commons as we see the adoption of InnerSource rapidly gaining momentum. I am confident Isabel, together with the new board will guide the Foundation through accelerated growth and success in the coming years.” said Danese Cooper, the Chairperson of The InnerSource Commons Foundation. 
 
 #### About InnerSource Commons
-InnerSource Commons is a growing community of InnerSource practitioners with the goal of creating and sharing knowledge about InnerSource.  The community provides free-to-use learning paths and curates known best practices in the form of patterns. They also organise the leading conferences dedicated to InnerSource, the InnerSource Commons Summits. Visit www.innersourcecommons.org to find out more.
+
+<p>
+{{< about-text >}}
+</p>

--- a/content/about/announcements/2021-09-sponsors.md
+++ b/content/about/announcements/2021-09-sponsors.md
@@ -31,10 +31,10 @@ More information about the InnerSource Commons Partner and Support programs can 
 "We have adopted InnerSource in Grupo Santander as a new way to scale collaboration across the organization, with the goal of being more effective in code reuse in our software production chain. Becoming a Supporter of InnerSource Commons allows us to work even more closely with global leaders in this space." said Jesus Alonso Gutiérrez, Head of European InnerSource Office, Grupo Santander.
 
 ### About InnerSource Commons
- 
-InnerSource Commons is the world's largest community of InnerSource practitioners. It is dedicated to creating and sharing knowledge about InnerSource, the use of open source best practices for software development within the confines of an organization.
- 
-Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.
+
+<p>
+{{< about-text >}}
+</p>
  
 ### Contact Information
  

--- a/content/about/announcements/2021-10-first-executive-director.md
+++ b/content/about/announcements/2021-10-first-executive-director.md
@@ -17,10 +17,10 @@ Clare is stepping into the role of Executive Director after a long career in the
 "InnerSource Commons provides a safe space for individuals to come together to share InnerSource knowledge and experiences, find best practices and research to accelerate the understanding, adoption, and practice of InnerSource. Having participated in this community for some time, I can say that it not only does amazing work, it is also a group that is a pleasure to work with." said Clare Dillon "I am looking forward to working more closely with the board and community to help grow the Commons and spread the word about how InnerSource can improve collaboration and pave the way to more sustainable development practices."
 
 ### About InnerSource Commons
- 
-InnerSource Commons is the world's largest community of InnerSource practitioners. It is dedicated to creating and sharing knowledge about InnerSource, the use of open source best practices for software development within the confines of an organization.
- 
-Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.
+
+<p>
+{{< about-text >}}
+</p>
  
 ### Contact Information
  

--- a/content/about/announcements/2021-11-outstanding-contributors.md
+++ b/content/about/announcements/2021-11-outstanding-contributors.md
@@ -23,10 +23,10 @@ This year’s award is going to:
 We would like to extend a massive thank you to the 3 exceptional contributors to our community and officially recognise them as the InnerSource Commons 2021 Outstanding Contributors. Hats off to you all!
 
 ### About InnerSource Commons
- 
-InnerSource Commons is the world's largest community of InnerSource practitioners. It is dedicated to creating and sharing knowledge about InnerSource, the use of open source best practices for software development within the confines of an organization.
- 
-Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.
+
+<p>
+{{< about-text >}}
+</p>
  
 ### Contact Information
  

--- a/layouts/shortcodes/about-text.html
+++ b/layouts/shortcodes/about-text.html
@@ -1,0 +1,3 @@
+InnerSource Commons is the world's largest community of InnerSource practitioners. It is dedicated to creating and sharing knowledge about InnerSource, the use of open source best practices for software development within the confines of an organization.
+<br />
+Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity.


### PR DESCRIPTION
Closes #236 

Created a new shortcode `{{< about-text >}}` with the next content:

```
InnerSource Commons is the world's largest community of InnerSource practitioners. It is dedicated to creating and sharing knowledge about InnerSource, the use of open source best practices for software development within the confines of an organization.

Founded in 2015, the InnerSource Commons is now supporting and connecting over 1500 individuals from over 500 companies, academic institutions, and government agencies. The InnerSource Commons Foundation was incorporated on February 19th, 2020 and is now a 501(c)(3) public charity. 
```

So it is possible to edit `layouts/shortcodes/about-text.html` file once and text will be changed everywhere, except https://innersourcecommons.org/community/action/ page: this page contains a different text and I left this untouched :) 