### PR TITLE
Adds basic link checker for links in content/community/action.md

### DIFF
--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,4 +1,4 @@
-ame: Links Check
+name: Links Check
 
 on:
   push:

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -2,7 +2,11 @@ name: Links Check
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
+  schedule:
+    - cron: '00 18 * * *'
 
 jobs:
   linkChecker:

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,0 +1,17 @@
+ame: Links Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.4.1
+        with:
+          fail: true
+          args: --verbose --no-progress --exclude=linkedin.com content/community/action.md


### PR DESCRIPTION
Motivated by the link fixes pushed in https://github.com/InnerSourceCommons/innersourcecommons.org/pull/256, I figured it might be good to have an automatic link checker for the links on the [InnerSource in Action](https://innersourcecommons.org/community/action/) page.

The tool used for checking the links is [lychee](https://github.com/lycheeverse/lychee). You can also install and run it locally, to test how it works outside of a GitHub Action (GHA), which is what I am using here to trigger it.

If a broken link is found, the GHA will fail, which will be visible under "Checks" in the PR.

The link checking has 3 different triggers:
1. push to master
2. any PR
3. and once per day (cron)
