### PR TITLE
Introducing CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# individuals that will receive automatic notifications about new PRs
+# for syntax details see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @voborgus @clcoffey


### PR DESCRIPTION
There was a question in Slack:

> Hey all, do I need to tag a reviewer(s) on a PR to change the website or do all the pull requests get checked regularly by someone? Asking because I was sure if I needed to list a reviewer on this pull request.

I am adding some people that know the website well to the `CODEOWNERS` file.
They will get notified of new PRs automatically.

I am tagging both people that I added as reviewers, so that they can decide themselves if they are happy to get these notifications

### Future

In a way this is the beginning of introducing the [Trusted Committers](https://patterns.innersourcecommons.org/p/trusted-committer) concept for this repo. (also see [example](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/TRUSTED-COMMITTERS.md) from the patterns repo))

