### PR TITLE
Make InnerSource in Action page searchable

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -120,10 +120,6 @@ ol.breadcrumb {
     vertical-align: -10%;
 }
 
-.company-logo {
-  margin-bottom: 0;
-}
-
 .not-found {
     position: relative;
     top: -100px;
@@ -152,12 +148,12 @@ ol.breadcrumb {
     margin-bottom: 1em;
 }
 
-[type='checkbox'].svelte-pv412u:checked+span.svelte-pv412u.svelte-pv412u, 
+[type='checkbox'].svelte-pv412u:checked+span.svelte-pv412u.svelte-pv412u,
     [type='radio'].svelte-pv412u:checked+span.svelte-pv412u.svelte-pv412u {
     color: white;
 }
 
-[type='checkbox'].svelte-pv412u+span.svelte-pv412u.svelte-pv412u, 
+[type='checkbox'].svelte-pv412u+span.svelte-pv412u.svelte-pv412u,
     [type='radio'].svelte-pv412u+span.svelte-pv412u.svelte-pv412u {
     font-size: 16px;
     font-family: pt sans,sans-serif;
@@ -249,4 +245,20 @@ button.svelte-la9dd4:disabled {
 
 .cite-text {
     display: none;
+}
+
+.company-logo-box {
+    position: relative;
+
+    img {
+      margin-bottom: 0;
+    }
+
+    div {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      opacity: 0;
+    }
 }

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -90,7 +90,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="Ericsson" image="/images/logos/ericsson.png" article="/learn/books/adopting-innersource-principles-and-case-studies" >}}
       {{< /company >}}
-      {{< company name="Etsy" image="/images/logos/etsy.png" article="https://github.com/customer-stories/etsy" author_name="Keyur Govande" author_title="Cheif Architect" >}}
+      {{< company name="Etsy" image="/images/logos/etsy.png" article="https://github.com/customer-stories/etsy" author_name="Keyur Govande" author_title="Chief Architect" >}}
       Everyone should be able to read the code that powers etsy.com and contribute to the broader success of the company.
       {{< /company >}}
       {{< company name="Europace" image="/images/logos/europace.png" article="/learn/books/adopting-innersource-principles-and-case-studies" >}}
@@ -99,7 +99,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="Fidelity Investments" image="/images/logos/fidelity.png" article="https://innersourcecommons.org/events/isc-fall-2018/" >}}
       {{< /company >}}
-      {{< company name="Ford" image="/images/logos/ford.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="KFlorian Frischmuth" author_title="Cheif Architect" >}}
+      {{< company name="Ford" image="/images/logos/ford.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Florian Frischmuth" author_title="Chief Engineer" >}}
       Our environment allows developers to find solutions that have already been developed. They can collaborate on those, and then reuse them.
       {{< /company >}}
       {{< company name="GitHub" image="/images/logos/github.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Martin Woodworth" author_title="Director, Developer Relations" >}}

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -210,8 +210,8 @@ image: "/images/learn/innersourceinaction.png"
       {{< company name="Trayio" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineering" >}}
       Anyone can learn something from another team and quickly see what’s in the code..Having a fairly open structure allows people to get involved quite easily and quickly.
       {{< /company >}}
-      {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}
-      We have an InnerSource policy, Everybody has access to create pull requests on all repositories. You can see all our code. We don’t lock down anything.
+      {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Martin Andersen" author_title="VP of Engineering" >}}
+      We have an InnerSource policy: Everybody has access to create pull requests on all repositories. You can see all our code. We don’t lock down anything.
       {{< /company >}}
       {{< company name="Twilio" image="/images/logos/twilio.png" article="https://github.com/customer-stories/twilio" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}
       Our development teams have benefited from the collaborative features of GitHub. It allows them to take co-development to a whole new level by working as a community and maturing our InnerSourcing practices.

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -213,8 +213,8 @@ image: "/images/learn/innersourceinaction.png"
       {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Martin Andersen" author_title="VP of Engineering" >}}
       We have an InnerSource policy: Everybody has access to create pull requests on all repositories. You can see all our code. We don’t lock down anything.
       {{< /company >}}
-      {{< company name="Twilio" image="/images/logos/twilio.png" article="https://github.com/customer-stories/twilio" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}
-      Our development teams have benefited from the collaborative features of GitHub. It allows them to take co-development to a whole new level by working as a community and maturing our InnerSourcing practices.
+      {{< company name="Twilio" image="/images/logos/twilio.png" article="https://github.com/customer-stories/twilio" author_name="Roman Scheiter" author_title="Head of Productivity Engineering" >}}
+      Twilio engineers are encouraged to submit pull requests to projects that are not immediately owned by their team. They can then work with the owning team on integrating their change into the code base.
       {{< /company >}}
       {{< company name="US Bank" image="/images/logos/usbank.png" video="https://youtu.be/4qT9wCz3hKw" >}}
       {{< /company >}}

--- a/content/community/action.md
+++ b/content/community/action.md
@@ -190,7 +190,7 @@ image: "/images/learn/innersourceinaction.png"
       {{< /company >}}
       {{< company name="Standard Charted" image="/images/logos/standard.png" article="https://www.linkedin.com/pulse/driving-innersourcing-through-collaboration-now-reality-george/?trackingId=BCPhjmSUTlmwMWi%2FymACww%3D%3D" >}}
       {{< /company >}}
-      {{< company name="Stripe" image="/images/logos/stripe.png" article="https://github.com/customer-stories/stripe" author_name="Micheal Advocate" author_title="Developer Advocate" >}}
+      {{< company name="Stripe" image="/images/logos/stripe.png" article="https://github.com/customer-stories/stripe" author_name="Michael Glukhovsky" author_title="Developer Advocate" >}}
       This internal community removes friction as we build software while making all of our projects more open and social.
       {{< /company >}}
       {{< company name="Taxfix" image="/images/logos/taxfix.png" article="https://www.linkedin.com/feed/update/urn:li:activity:6765182430468030464/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6765182430468030464%29" >}}

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -10,7 +10,7 @@
     </div>
     {{ if (not (eq (trim .Inner "\n ") "")) }}
       <div id="{{ urlize (.Get "name")}}-cite" class="cite-text">
-      <p><cite>“{{ .Inner }}”</cite></p>
+      <p><cite>“{{ trim .Inner "\n " }}”</cite></p>
       {{ if .Get "author_name" }}<a href="{{ .Get "link" }}"><b>{{ .Get "author_name" }}</b>, {{ .Get "author_title" }}</a>{{ end }}
       </div>
     {{ end }}

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -1,7 +1,8 @@
 <div class="col-md-4 col-sm-6 mb-4">
   <div class="feature-card bg-light text-center mb-0">
-    <div class="h-150 d-flex align-items-center justify-content-center mb-0">
-      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" title="{{ .Get "name" }}" class="mh-150 company-logo">
+    <div class="h-150 d-flex align-items-center justify-content-center mb-0 company-logo-box">
+      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" title="{{ .Get "name" }}" class="mh-150">
+      <div>{{ .Get "name" }}</div>
     </div>
     <div class="cite-icons mt-1 align-items-center justify-content-center mb-0">
       {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -4,7 +4,7 @@
       <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" class="mh-150 company-logo">
     </div>
     <div class="cite-icons mt-1 align-items-center justify-content-center mb-0">
-      {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite" bla="{{ trim .Inner "\n " }}"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}
+      {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}
       {{ if .Get "video" }}<a href="{{ .Get "video" }}" target="_blank"><i class="ti-video-camera mb-0 mr-1 ml-1"></i></a>{{ end }}
       {{ if .Get "article" }}<a href="{{ .Get "article" }}" target="_blank"><i class="ti-book mb-0 ml-1"></i></a>{{ end }}
     </div>

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -1,7 +1,7 @@
 <div class="col-md-4 col-sm-6 mb-4">
   <div class="feature-card bg-light text-center mb-0">
     <div class="h-150 d-flex align-items-center justify-content-center mb-0">
-      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" class="mh-150 company-logo">
+      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" title="{{ .Get "name" }}" class="mh-150 company-logo">
     </div>
     <div class="cite-icons mt-1 align-items-center justify-content-center mb-0">
       {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}


### PR DESCRIPTION
Pseudo user story:

> As a user, I want to quickly determine if a given company is mentioned on the [InnerSource in Action](https://innersourcecommons.org/community/action/) page (using the "browser search").

Currently this doesn't work, as we only show the logos of the companies on that page but not their names as text. 
See screenshot.

<img width="914" alt="Screenshot 2022-04-21 at 13 21 14 " src="https://user-images.githubusercontent.com/163029/164448029-8ef450dc-62e4-4079-9de1-afafc0df9751.png">

I don't know how to fix this, other than adding the company name as text to the page, which we likely don't want?

### Other changes in this PR

While trying to fix this, I also made some other improvements.

- Removing dummy attribute that I had used for debugging during #230. It was committed by accident.
- Removing empty space before and after the company quotes
- Add `title` attribute to company logos (show on mouse-over on the logos)
