### PR TITLE
Fixed bullet point vertical alignment in css

### DIFF
--- a/assets/scss/templates/_main.scss
+++ b/assets/scss/templates/_main.scss
@@ -118,7 +118,7 @@ a.post-title {
         border-radius: 50%;
         background: $primary-color;
         left: 3px;
-        top: 5px;
+        top: 12px;
       }
     }
   }


### PR DESCRIPTION
Bullet points were moved slightly above their original position on all devices. This has now been fixed in styles.

![screenshot](https://user-images.githubusercontent.com/33402306/180464824-c1152336-bd27-4951-b06d-518f7b4b1ec7.jpg)
Previous bullet positions (left of image) and updated bullet positions (right of image).
