### PR TITLE
Fix website build break

### DIFF
--- a/content/stories/_index.md
+++ b/content/stories/_index.md
@@ -141,9 +141,9 @@ aliases:
       {{< /company >}}
       {{< company name="Intuit" image="/images/logos/intuit.png" article="https://builtin.com/software-engineering-perspectives/intuit-duplication-innersource" >}}
       {{< /company >}}
-      {{< company name="Knock" image="/images/logos/knock.png" article="https://github.com/customer-stories/knock" >
+      {{< company name="Knock" image="/images/logos/knock.png" article="https://github.com/customer-stories/knock" >}}
       {{< /company >}}
-      {{< company name="KPMG" image="static/images/logos/KPMG.png" article="https://github.com/customer-stories/kpmg" >
+      {{< company name="KPMG" image="static/images/logos/KPMG.png" article="https://github.com/customer-stories/kpmg" >}}
       {{< /company >}}
       {{< company name="Leroy Merlin" image="/images/logos/leroymerlin.png" video="https://www.youtube.com/watch?v=Wzg8h30OhK8" >}}
       {{< /company >}}


### PR DESCRIPTION
You can see the failure [here](https://github.com/InnerSourceCommons/innersourcecommons.org/runs/7770367372?check_suite_focus=true).

`Error building site: "/home/runner/work/innersourcecommons.org/innersourcecommons.org/content/stories/_index.md:144:116": unrecognized character in shortcode action: U+003E '>'. Note: Parameters with non-alphanumeric args must be quoted`

Looks like the closing curly braces were forgotten (`}}`).