### PR TITLE
ISC Summit 2022 - event page fixes

### DIFF
--- a/content/events/isc-2022.md
+++ b/content/events/isc-2022.md
@@ -239,7 +239,7 @@ Our summit is planned over multiple time zones so we look forward to seeing you 
   
   <tr>
         <td class="time">08:45 - 09:00</td>
-	<td class="author"> <b><a href="#tom_sadler">Tom Sadler</a></b> (Bitergia)<br>
+	<td class="author"> <b><a href="#tom_sadler">Tom Sadler</a></b> (BBC)<br>
     Decision Making at Scale
 	</td>
   	<td class="author"> <b><a href="#sebastian_spier">Sebastian Spier</a></b> (Meltwater)<br>

--- a/content/events/isc-2022.md
+++ b/content/events/isc-2022.md
@@ -83,7 +83,7 @@ Our summit is planned over multiple time zones so we look forward to seeing you 
 	<td class="author"> <b><a href="#russell_rutledge">Russell Rutledge</a></b> (Wellsky)<br>
     Continuous InnerSource in Production (5 times)
 	</td>
-  	<td class="author"> <b><a href="#natalie_bradley">Natlaie Bradley</a></b> (GitHub)<br>
+  	<td class="author"> <b><a href="#natalie_bradley">Natalie Bradley</a></b> (GitHub)<br>
     Foundations of InnerSource Culture
 	</td>
 


### PR DESCRIPTION
Some small fixes to this page
https://innersourcecommons.org/events/isc-2022/

- Fix company name of Tom Sadler
- Fix name of Natalie

I also noticed that the profile image for "Chamindra de Silva" is missing from the event page.
However it looks like that image is not available in this repo yet?