### PR TITLE
Create Blagslide

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -267,6 +267,10 @@ button.svelte-la9dd4:disabled {
     }
 }
 
+.company-logo-box-bragslide, .company-logo-box-bragslide * {
+    margin-bottom: 1px;
+}
+
 .board-profile {
     filter: grayscale(100%) brightness(105%);
     display: inline-block;

--- a/content/stories/bragslide.md
+++ b/content/stories/bragslide.md
@@ -1,0 +1,272 @@
+---
+layout: page
+title: "Brag Slide"
+subtitle: "An overview of all known InnerSource adopters, that can be copied into a slide for presentations."
+image: "/images/learn/InnerSourceInAction.jpg"
+---
+  <div class="container">
+    <div class="row justify-content-center">
+      {{< company name="3M" image="/images/logos/3m.png" article="https://github.com/customer-stories/3m" author_name="Kevin Truckenmiller" author_title="Lead DevOps Engineer in CRSL" >}}
+      We’re moving towards more openness, which ultimately creates a communication culture and a generative culture, rather than one that’s bureaucratic and process-based.
+      {{< /company >}}
+      {{< company name="ADEO" image="/images/logos/adeo.png" article="https://github.com/customer-stories/adeo" author_name="Guilherme Guitte" author_title="Lead Developer Advocate" >}}
+      InnerSource paves the way for ADEO to introduce new open source projects and give developers more freedom.
+      {{< /company >}}
+      {{< company name="Adobe" image="/images/logos/adobe.png" article="https://medium.com/adobetech/open-development-inner-source-and-open-source-46c2ba174be6" >}}
+      {{< /company >}}
+     {{< company name="Ahold Delhaize" image="/images/logos/ahold.png" article="https://github.com/customer-stories/ahold-delhaize" author_name="Joost Hofman" author_title="Head of Tech Enabling" >}}
+      If we give people the right tools and the right platform, it’s a start. We can share more within our company and with each other, growing as an InnerSource organization.
+      {{< /company >}}
+      {{< company name="Alliander" image="/images/logos/alliander.png" video="https://youtu.be/Q6yCZI4f2bo?t=1131" >}}
+      {{< /company >}}
+      {{< company name="American Airlines" image="/images/logos/americanairlines.png" article="https://tech.aa.com/2020-10-30-innersource/" >}}
+      {{< /company >}}
+      {{< company name="Anyshore" image="/images/logos/Anyshore.png" article="https://www.linkedin.com/pulse/anyshore-innersource-journey-lisalee-tunde-farrell/?trackingId=2whtvdgFQga8y6CG8N9TOg%3D%3D" >}}
+      {{< /company >}}
+      {{< company name="ASOS" image="/images/logos/asos.png" article="https://medium.com/asos-techblog/adopting-innersource-at-asos-5618435c8d7" author_name="Rob Bell" author_title="Principal Software Engineer" >}}
+      InnerSource has allowed us to deliver dozens of cross-cutting features more efficiently, spanning multiple teams and services.
+      {{< /company >}}
+      {{< company name="Autodesk" image="/images/logos/autodesc.png" article="https://github.com/customer-stories/autodesk" >}}
+      {{< /company >}}
+      {{< company name="Avalia Systems" image="/images/logos/avalia.png" article="https://innersourcecommons.org/events/isc-spring-2019/" >}}
+      {{< /company >}}
+      {{< company name="AXA" image="/images/logos/axa.png" article="https://www.linkedin.com/feed/update/urn:li:activity:6732939790041268224/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6732939790041268224%29" >}}
+      {{< /company >}}
+      {{< company name="Baidu" image="/images/logos/baidu.png" article="https://conferences.oreilly.com/oscon/oscon-or-2019/public/schedule/detail/75342.html" >}}
+      {{< /company >}}
+      {{< company name="BBC" image="/images/logos/bbc.png" video="https://www.youtube.com/watch?v=pEGMxe6xz-0" author_name="Steph Egan" author_title="Software Engineering Team Lead" >}}
+      Our tools have been built been built from the ground up with an expectation of InnerSource … The way that we encourage that in a very disparate organization is mostly word of mouth and clear documentation.
+      {{< /company >}}
+      {{< company name="BCG Gamma" image="/images/logos/bcg.png" article="https://github.com/customer-stories/bcg-gamma" >}}
+      {{< /company >}}
+      {{< company name="Bitergia" image="/images/logos/bitergia.png" article="https://www.linkedin.com/feed/update/urn:li:activity:6711604569262067712/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6711604569262067712%29" >}}
+      {{< /company >}}
+      {{< company name="Bloomberg" image="/images/logos/bloomberg.png" article="https://resources.github.com/whitepapers/introduction-to-innersource/" author_name="Panna Pavangadkar" author_title="Global Head of Engineering Developer Experience" >}}
+      InnerSource is not new to Bloomberg … our competitive advantage is really in being able to innovate, come up with new ideas and get them out to our specialized consumers on a regular basis at the speed that they require it to be competitive in the market.
+      {{< /company >}}
+      {{< company name="Bosch" image="/images/logos/bosch.png" article="https://www.bosch.com/research/know-how/open-and-inner-source/" author_name="Georg Grütter" author_title="Chief Expert Social Coding" >}}
+      InnerSource has proven invaluable for us. It has become the gold standard for internal collaboration on software at Bosch.
+      {{< /company >}}
+      {{< company name="BuzzFeed" image="/images/logos/buzzfeed.png" article="https://github.com/customer-stories/buzzfeed" >}}
+      {{< /company >}}
+      {{< company name="Capital One" image="/images/logos/capitalone.png" video="https://www.youtube.com/watch?v=1jiAGQ7y_vQ&t=130s" author_name="Roderick Randolph" author_title="Capital One" >}}
+        Our InnerSource journey started small and then started to grow to an enterprise scale.
+      {{< /company >}}
+      {{< company name="CA Technologies" image="/images/logos/CA_Technologies.png" article="https://innersourcecommons.org/events/isc-fall-2018/" >}}
+      {{< /company >}}
+      {{< company name="Capillary" image="/images/logos/capillary.png" article="https://github.com/customer-stories/capillarytech" author_name="Piyush Goel" author_title="VP of Engineering" >}}
+      InnerSource has absolutely made our developers stronger.
+      {{< /company >}}
+      {{< company name="Comcast" image="/images/logos/comcast.png" video="https://www.youtube.com/watch?v=msD-8-yrGfs&t=6s" author_name="Nithya Ruff" author_title="Head of Comcast’s Open Source Program Office" >}}
+      InnerSource helped us create a community inside the company... InnerSource is truly a cultural transformation.
+      {{< /company >}}
+       {{< company name="Commonwealth Bank Austrailia" image="/images/logos/cba.png" article="https://www.itnews.com.au/news/cba-to-treat-its-software-like-food-in-the-fridge-570930" >}}
+      {{< /company >}}
+      {{< company name="CHR" image="/images/logos/chr.png" article="https://github.com/customer-stories/ch-robinson/" >}}
+      {{< /company >}}
+      {{< company name="Continental" image="/images/logos/continental.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Zsuzsanna Gnandt" author_title="InnerSource Project Manager" >}}
+      With InnerSource, we want to enable all developers with the freedom to be creative, to drive innovation without barriers, and to be appreciated for their contributions across the company.
+      {{< /company >}}
+      {{< company name="Daimler" image="/images/logos/daimler.png" video="https://www.youtube.com/watch?v=lBcs97RgsAw" >}}
+      {{< /company >}}
+      {{< company name="Decathlon" image="/images/logos/decathlon.png" article="https://github.com/customer-stories/decathlon" >}}
+      {{< /company >}}
+      {{< company name="Deliveroo" image="/images/logos/deliveroo.png" article="https://github.com/customer-stories/deliveroo" >}}
+      static/images/logos/deloitte.png
+      {{< /company >}}
+      {{< company name="Daimler" image="/images/logos/deloitte.png" video="https://www.youtube.com/watch?v=e9GQ1I-0wEs" >}}
+      {{< /company >}}
+      {{< company name="Deutche Bank" image="/images/logos/deutschebank.png" article="https://www.finos.org/blog/how-deutsche-bank-uses-innersource-in-engineering-daniela-zheleva" >}}
+      {{< /company >}}
+      {{< company name="Didi" image="/images/logos/didi.png" video="https://www.youtube.com/watch?v=h7PheT0qZsM" >}}
+      {{< /company >}}
+      {{< company name="Disney" image="/images/logos/disney.png" article="https://innersourcecommons.org/events/isc-fall-2018/" >}}
+      {{< /company >}}
+      {{< company name="Dow Jones" image="/images/logos/dowjones.png" article="https://github.com/customer-stories/dow-jones" >}}
+      {{< /company >}}
+      {{< company name="DXC Technology" image="/images/logos/dxc.png" article="https://resources.github.com/whitepapers/introduction-to-innersource/" author_name="Joan Watson" author_title="Research and Developement IT" >}}
+      What we're seeing now is the technology has caught up with all these ideas of innovation and collaboration, and that's really critical for us.
+      {{< /company >}}
+      {{< company name="Elbit Systems" image="/images/logos/elbit.png" article="/events/isc-spring-2019" >}}
+      {{< /company >}}
+      {{< company name="ENGIE Digital" image="/images/logos/engie.png" article="https://github.com/customer-stories/engie" >}}
+      {{< /company >}}
+      {{< company name="Entelgy" image="/images/logos/entelgy.png" article="https://www.entelgy.com/actualidad/resumen-de-eventos/resumen/innersource-open-source" >}}
+      {{< /company >}}
+      {{< company name="Ericsson" image="/images/logos/ericsson.png" article="/learn/books/adopting-innersource-principles-and-case-studies" >}}
+      {{< /company >}}
+      {{< company name="Etsy" image="/images/logos/etsy.png" article="https://github.com/customer-stories/etsy" author_name="Keyur Govande" author_title="Chief Architect" >}}
+      Everyone should be able to read the code that powers etsy.com and contribute to the broader success of the company.
+      {{< /company >}}
+      {{< company name="Europace" image="/images/logos/europace.png" article="/learn/books/adopting-innersource-principles-and-case-studies" >}}
+      {{< /company >}}
+      {{< company name="EXFO Inc." image="/images/logos/exfo.png" article="https://innersourcecommons.org/events/isc-fall-2018/" >}}
+      {{< /company >}}
+      {{< company name="Fannie Mae" image="/images/logos/Fannie_Mae.png" video="https://www.youtube.com/watch?v=S-Yiamq9bUw" >}}
+      {{< /company >}}
+      {{< company name="Fidelity Investments" image="/images/logos/fidelity.png" article="https://innersourcecommons.org/events/isc-fall-2018/" >}}
+      {{< /company >}}
+      {{< company name="Ford" image="/images/logos/ford.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Florian Frischmuth" author_title="Chief Engineer" >}}
+      Our environment allows developers to find solutions that have already been developed. They can collaborate on those, and then reuse them.
+      {{< /company >}}
+      {{< company name="GitHub" image="/images/logos/github.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Martin Woodworth" author_title="Director, Developer Relations" >}}
+      The reason why InnerSource works is because like open source you're working with people who are collaborating with different priorities because they're working on different things
+      {{< /company >}}
+      {{< company name="GitLab" image="/images/logos/gitlab.png" article="https://about.gitlab.com/solutions/innersource/" >}}
+      {{< /company >}}
+      {{< company name="Globant" image="/images/logos/globant.png" article="https://github.com/customer-stories/globant/" >}}
+      {{< /company >}}
+      {{< company name="HBR" image="/images/logos/hbr.png" article="/events/isc-spring-2019" >}}
+      {{< /company >}}
+      {{< company name="HERE Global B.V" image="/images/logos/here.png" article="https://innersourcecommons.org/events/isc-spring-2019/" >}}
+      {{< /company >}}
+      {{< company name="Huawei" image="/images/logos/huawei.png" video="https://www.youtube.com/watch?v=MhNnK_VPLVI" author_name="Willem Jiang and Long Li" author_title="Huawei" >}}
+      We need to build a community around the InnerSource projects of people who share the same ideals.
+      {{< /company >}}
+      {{< company name="IAG" image="/images/logos/iag.png" article="https://thenewstack.io/open-source-best-insurance-future-eddie-satterly-talks-iag/" >}}
+      {{< /company >}}
+      {{< company name="IBM" image="/images/logos/ibm.png" article="https://resources.github.com/whitepapers/introduction-to-innersource/" author_name="Jeff Jagoda" author_title="Senior Site Engineer" >}}
+      We see InnerSource as a way to improve efficiency through code reuse. But even beyond that, it's an amazing conduit for learning and exchanging ideas and facilitating innovation within IBM.
+      {{< /company >}}
+      {{< company name="Indeed" image="/images/logos/indeed.png" video="https://www.youtube.com/watch?v=hVcGABbmI4Y" >}}
+      {{< /company >}}
+      {{< company name="ING Bank" image="/images/logos/ING_Bank.png" video="https://www.youtube.com/watch?v=277mzDL12Q4" >}}
+      {{< /company >}}
+      {{< company name="Intuit" image="/images/logos/intuit.png" article="https://builtin.com/software-engineering-perspectives/intuit-duplication-innersource" >}}
+      {{< /company >}}
+      {{< company name="Knock" image="/images/logos/knock.png" article="https://github.com/customer-stories/knock" >}}
+      {{< /company >}}
+      {{< company name="KPMG" image="/images/logos/KPMG.png" article="https://github.com/customer-stories/kpmg" >}}
+      {{< /company >}}
+      {{< company name="Leroy Merlin" image="/images/logos/leroymerlin.png" video="https://www.youtube.com/watch?v=Wzg8h30OhK8" >}}
+      {{< /company >}}
+      {{< company name="Llyods" image="/images/logos/lloyds.png" article="https://www.nearform.com/blog/journey-to-innersource-danese-cooper-james-mcleod/"  >}}
+      {{< /company >}}
+      {{< company name="Mercari" image="/images/logos/mercari.png" article="https://github.com/customer-stories/mercari" >}}
+      {{< /company >}}
+      {{< company name="Mercedes Benz" image="/images/logos/Mercedes_Benz.png" video="https://www.youtube.com/watch?v=hVcGABbmI4Y" >}}
+      {{< /company >}}
+      {{< company name="Microsoft" image="/images/logos/microsoft.png" video="https://www.youtube.com/watch?v=eZdx5MQCLA4" author_name="Arno Mihm" author_title="Program Manager InnerSource" >}}
+      We have seen greater engineering satisfaction among teams that practice InnerSource... we have [also] seen better product quality and responses because of InnerSource.
+      {{< /company >}}
+      {{< company name="Morgan Stanley" image="/images/logos/morganstanley.png" video="https://www.youtube.com/watch?v=Z2l3rB9ewC8" >}}
+      {{< /company >}}
+      {{< company name="NASA" image="/images/logos/NASA.png" article="/events/isc-fall-2018" >}}
+      {{< /company >}}
+      {{< company name="Nab" image="/images/logos/nab.jpg" video="https://www.youtube.com/watch?v=1jiAGQ7y_vQ&t=130s" >}}
+      {{< /company >}}
+      {{< company name="Nationwide" image="/images/logos/nationwide.png" article="https://github.blog/2020-03-11-why-organizations-should-commit-to-innersource-in-2020/" author_name="Cindy Payne" author_title="Associate Vice President of IT Application Services" >}}
+      We knew (with InnerSource)  were going to save money, but that savings immediately turned into more capacity for teams to do the most valuable work for our business.
+      {{< /company >}}
+      {{< company name="Navex Global" image="/images/logos/navex-global.png" article="http://mxmossman.blogspot.com/2017/01/pnsqc-2016-day-1.html" >}}
+      {{< /company >}}
+      {{< company name="Nokia" image="/images/logos/nokia.png" article="/events/isc-fall-2017" >}}
+      {{< /company >}}
+      {{< company name="Nike" image="/images/logos/nike.png" video="https://www.youtube.com/watch?v=srPG-Tq0HIs&list=PLq-odUc2x7i-A0sOgr-5JJUs5wkgdiXuR&index=45" author_name="Russ Rutledge" author_title="Director of Community and InnerSource" >}}
+      We found it very useful to work within the InnerSource Commons.. Where you can bounce ideas off of other InnerSource practitioners
+      {{< /company >}}
+      {{< company name="Nuance" image="/images/logos/nuance.png" video="https://www.youtube.com/watch?v=2CwwFhr34jI" >}}
+      {{< /company >}}
+      {{< company name="Nubank" image="/images/logos/nubank.png" article="https://github.com/customer-stories/nubank" author_name="Haberkorn Gomes" author_title="Infosec Tech Manager" >}}
+      We try to standardize our code style, our languages so that everybody can contribute to repositories. It’s really good for me making a change on a project, a service skeleton, or a common library to know that everybody’s going to use that to deploy their service.
+      {{< /company >}}
+      {{< company name="Otto Group" image="/images/logos/ottogroup.png" article="https://github.com/customer-stories/otto-group" >}}
+      {{< /company >}}
+      {{< company name="PayPal" image="/images/logos/paypal.png" article="/learn/books/adopting-innersource-principles-and-case-studies" author_name="Sathish Vaidyanathan" author_title="Adopting InnerSource Book" >}}
+      The Process of InnerSource is actually the mindset of Collaboration.
+      {{< /company >}}
+      {{< company name="Philips" image="/images/logos/philips.png" article="https://www.infoq.com/articles/inner-source-open-source-development-practices/" >}}
+      {{< /company >}}
+      {{< company name="Plaid" image="/images/logos/plaid.png" article="https://github.com/customer-stories/plaid" >}}
+      {{< /company >}}
+      {{< company name="Publicis Sapient" image="/images/logos/publicis sapient.png" article="https://www.publicissapient.com/insights/decoding-organizational-agility-with-innersource?utm_medium=organic-social&utm_source=twitter&userID=aa0e6055-f6dd-4611-9c21-ea56d77cb680&utm_category=Brand&utm_campaign=everyonesocial&es_id=d19e3b636b">}}
+      {{< /company >}}
+      {{< company name="Royal Bank of Canada" image="/images/logos/rbc.png" article="https://www.finos.org/blog/innersource-as-the-first-step-toward-open-source-anthony-vacca-rbc" video="https://www.youtube.com/watch?v=QbJ4VFk8DwA">}}
+      {{< /company >}}
+      {{< company name="Reserve Bank of India" image="/images/logos/rbi.png" video="https://videos.itrevolution.com/watch/707352100/">}}
+      {{< /company >}}
+      {{< company name="Grupo Santander" image="/images/logos/santander.png" video="https://www.youtube.com/watch?v=277mzDL12Q4&ab_channel=InnerSourceCommons" >}}
+      {{< /company >}}
+      {{< company name="SAP" image="/images/logos/sap.png" video="https://www.youtube.com/watch?v=2nhKMcv5STc&t=269s" author_name="Micheal Graf and Guilherme Dellagustin" author_title="SAP" >}}
+      We work together as a team to provide InnerSource methodology to encourage new people to initiate new projects... 70% of SAP employees would like to contribute if suitable projects are available.
+      {{< /company >}}
+      {{< company name="SberBank" image="/images/logos/sberbank.png" article="https://habr.com/ru/company/sberbank/blog/503902/" >}}
+      {{< /company >}}
+      {{< company name="Seagate" image="/images/logos/seagate.png" article="https://github.com/customer-stories/seagate" >}}
+      {{< /company >}}
+      {{< company name="Shell" image="/images/logos/shell.png" video="https://youtu.be/7AJuMROHRHY" >}}
+      {{< /company >}}
+      {{< company name="Shutterstock" image="/images/logos/shutterstock.png" article="https://panelpicker.sxsw.com/vote/89929" >}}
+      {{< /company >}}
+      {{< company name="Siemens" image="/images/logos/siemens.png" article="https://jfrog.com/blog/creating-an-inner-source-hub-at-siemens/" >}}
+      {{< /company >}}
+      {{< company name="Skyscanner" image="/images/logos/skyscanner.png" article="https://github.com/customer-stories/skyscanner" >}}
+      {{< /company >}}
+      {{< company name="Societe Generale" image="/images/logos/societegenerale.png" article="https://github.com/customer-stories/societe-generale" >}}
+      {{< /company >}}
+      {{< company name="Sourcegraph" image="/images/logos/sourcegraph.svg" article="https://about.sourcegraph.com/podcast/jonathan-carter/" >}}
+      {{< /company >}}
+      {{< company name="Spotify" image="/images/logos/spotify.png" article="https://github.com/customer-stories/spotify" author_name="Laurent Ploix" author_title="Product Manager" >}}
+      Pull requests are welcome. Someone out there might find a better solution than I can.
+      {{< /company >}}
+      {{< company name="Stack Overflow" image="/images/logos/stackoverflow.png" article="https://www.linkedin.com/pulse/innersource-angle-billion-dollar-use-case-stack-overflow-abbott/?trackingId=2%2FslhezVShW%2BPwsHQ5iTKQ%3D%3D" >}}
+      {{< /company >}}
+      {{< company name="Standard Charted" image="/images/logos/standard.png" article="https://www.linkedin.com/pulse/driving-innersourcing-through-collaboration-now-reality-george/?trackingId=BCPhjmSUTlmwMWi%2FymACww%3D%3D" >}}
+      {{< /company >}}
+      {{< company name="Stripe" image="/images/logos/stripe.png" article="https://github.com/customer-stories/stripe" author_name="Michael Glukhovsky" author_title="Developer Advocate" >}}
+      This internal community removes friction as we build software while making all of our projects more open and social.
+      {{< /company >}}
+      {{< company name="Taxfix" image="/images/logos/taxfix.png" article="https://www.linkedin.com/feed/update/urn:li:activity:6765182430468030464/?updateEntityUrn=urn%3Ali%3Afs_feedUpdate%3A%28V2%2Curn%3Ali%3Aactivity%3A6765182430468030464%29" >}}
+      {{< /company >}}
+      {{< company name="Tencent" image="/images/logos/tencent.png" video="https://www.youtube.com/watch?v=JCHbtKu71SQ" author_name="Jerry Tan" author_title="Tencent" >}}
+      [Tencent] adopted InnerSource to promote engineer culture inside the company... 80% of  projects get InnerSourced.
+      {{< /company >}}
+      {{< company name="Thales" image="/images/logos/thales.png" article="https://innersourcecommons.org/events/isc-spring-2019/" >}}
+      {{< /company >}}
+      {{< company name="Tesco" image="/images/logos/tesco.png" article="https://www.linkedin.com/pulse/perspectives-from-tesco-hosted-first-github-meetup-bengaluru-manly/?trackingId=KsNFK4fqT%2Fa%2BS%2BZ8zchGvQ%3D%3D" >}}
+      {{< /company >}}
+      {{< company name="The Hartford" image="/images/logos/thehartford.png" article="https://github.com/customer-stories/the-hartford" author_name="Jo Ann Tan" author_title="Vice President and Head of Infrastructure" >}}
+      Our development teams have benefited from the collaborative features of GitHub. It allows them to take co-development to a whole new level by working as a community and maturing our InnerSourcing practices.
+      {{< /company >}}
+      {{< company name="Toshiba" image="/images/logos/toshiba.png" article="https://eventyay.com/e/3dbaaa50" >}}
+      {{< /company >}}
+      {{< company name="Trayio" image="/images/logos/tray.png" article="https://github.com/customer-stories/trayio" author_name="Alberto Giorgi" author_title="Director of Engineering" >}}
+      Anyone can learn something from another team and quickly see what’s in the code..Having a fairly open structure allows people to get involved quite easily and quickly.
+      {{< /company >}}
+      {{< company name="Trend Micro" image="/images/logos/trend-micro.png" video="https://www.youtube.com/watch?v=e9GQ1I-0wEs" >}}
+      {{< /company >}}
+      {{< company name="Trustpilot" image="/images/logos/trustpilot.png" article="https://github.com/customer-stories/trustpilot" author_name="Martin Andersen" author_title="VP of Engineering" >}}
+      We have an InnerSource policy: Everybody has access to create pull requests on all repositories. You can see all our code. We don’t lock down anything.
+      {{< /company >}}
+      {{< company name="Twilio" image="/images/logos/twilio.png" article="https://github.com/customer-stories/twilio" author_name="Roman Scheiter" author_title="Head of Productivity Engineering" >}}
+      Twilio engineers are encouraged to submit pull requests to projects that are not immediately owned by their team. They can then work with the owning team on integrating their change into the code base.
+      {{< /company >}}
+      {{< company name="US Bank" image="/images/logos/usbank.png" video="https://youtu.be/4qT9wCz3hKw" >}}
+      {{< /company >}}
+      {{< company name="ViacomCBS" image="/images/logos/viacomcbs.png" article="https://github.com/customer-stories/viacomcbs-streaming" >}}
+      {{< /company >}}
+      {{< company name="Vmware" image="/images/logos/vmware.png" video="https://www.youtube.com/watch?v=Y6biezNfJOM" author_name="Minchene Tang" author_title="Vmware" >}}
+      A project isn’t just about the code, there’s a team behind it, including writers, designers and project managers. [InnerSource] gives you the opportunity to collaborate across multiple time zones and business units.
+      {{< /company >}}
+      {{< company name="Walmart" image="/images/logos/walmart.png" article="https://resources.github.com/whitepapers/introduction-to-innersource/" author_name="Jeremy King" author_title="Executive Vice President & CTO for Global eCommerce" >}}
+      Once you embrace it [InnerSource] and see new teams come on, you show examples of places where not only can people contribute, you unlock bottlenecks
+      {{< /company >}}
+      {{< company name="WayFair" image="/images/logos/wayfair.png" article="https://github.com/customer-stories/wayfair">}}
+      {{< /company >}}
+      {{< company name="Wellsky" image="/images/logos/wellsky.png" video="https://youtu.be/kgxexjYdhIc" >}}
+      {{< /company >}}
+      {{< company name="John Wiley and Sons" image="/images/logos/wiley.png" article="https://github.com/customer-stories/wiley" author_name="Fedor Terlov" author_title="Director of Site Reliability" >}}
+      Suddenly developers are buttoning up the structure of their code—open source and InnerSource act as a forcing function to get the details right and ready for more eyes.
+      {{< /company >}}
+      {{< company name="Wipro" image="/images/logos/wipro.png" video="https://www.youtube.com/watch?v=vApVU26TZGo" author_name="Andrew Aitken" author_title="Wipro" >}}
+      We have thousands of developers working on these projects today and at any given time we’re doing dozens of different projects... 75% of our clients with large global enterprises are trying InnerSource in some way, shape or form.
+      {{< /company >}}
+      {{< company name="Zalando" image="/images/logos/zalando.png" article="https://opensource.zalando.com/docs/resources/innersource-howto/" >}}
+      {{< /company >}}
+      {{< company name="Zendesk" image="/images/logos/zendesk.png" article="https://github.com/customer-stories/zendesk" author_name="Jason Smale" author_title="VP of Engineering" >}}
+      Our engineering culture is open and centred around teams owning services and being responsible for running them in production.
+      {{< /company >}}
+      {{< company name="Zymple" image="/images/logos/zymple.png" video="https://youtu.be/QWbxXp5-nOQ" >}}
+      {{< /company >}}
+    </div>
+  </div>

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -1,3 +1,13 @@
+{{ if (eq .Page.RelPermalink "/stories/bragslide/") }} 
+
+<div class="col-md-1 d-flex align-items-center company-logo-box-bragslide">
+  <div>
+    <img src="{{ .Get "image" }}">
+  </div>
+</div>
+
+{{ else }}
+
 <div class="col-md-4 col-sm-6 mb-4">
   <div class="feature-card bg-light text-center mb-0">
     <div class="h-150 d-flex align-items-center justify-content-center mb-0 company-logo-box">
@@ -17,3 +27,6 @@
     {{ end }}
   </div>
 </div>
+
+
+{{ end }}


### PR DESCRIPTION
For presentations we frequently need a "brag slide", i.e. an overview of all known InnerSource adopters.

We already have the [stories](https://innersourcecommons.org/stories/) page with an overview of all adopters.
However we cannot easily copy all company images from there as the page is too large to fit into a slide.

In this PR I am creating a new page, that isn't liked from anywhere. It is located at:
`/stories/bragslide/`

It shows all the logos in a much more dense form, and with smaller logo images.

Left to do:

- [ ] prevent duplicating all the company data in two files - can I load that data from a separate file into two pages?
- [ ] fix logo for sourcegraph (apparently the `.svg` does not work in the bragslide yet
- [ ] determine now to call this thing. `bragslide` might not be proper :)

Current status:

![Screenshot 2022-11-10 at 11 15 10 ](https://user-images.githubusercontent.com/163029/201064562-d1da623c-c3ab-4834-a0ff-e5010eb4e50f.png)





