### PR TITLE
Remove errant chars

### DIFF
--- a/content/learn/patterns.md
+++ b/content/learn/patterns.md
@@ -62,4 +62,3 @@ weight: 1
 ## How to Get Involved
 
 If you are using InnerSource in your company already and want to contribute to the efforts outlined above by sharing your experiences or introducing new patterns, we would love to <a href="https://patterns.innersourcecommons.org/contribute"> welcome your contributions to the book</a> and to our Slack conversations in the <a href="https://innersourcecommons.slack.com/archives/C2EFRTS6A">#innersource-patterns channel</a>.
-t 


### PR DESCRIPTION
Note the "t" character that is at the end of the paragraph. This PR removes the hanging "t" character.
<img width="942" alt="Screenshot 2022-11-14 at 3 17 23 PM" src="https://user-images.githubusercontent.com/6935431/201788396-023885f8-d6a7-4b05-8c6e-f8a88144e49f.png">

