### PR TITLE
Add i18n consistency check GitHub Action

### DIFF
--- a/.github/workflows/i18n-consistency-check.yml
+++ b/.github/workflows/i18n-consistency-check.yml
@@ -1,0 +1,106 @@
+name: i18n check consistency and notify on GitHub Issues
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - content/en/**
+      - .github/workflows/i18n-consistency-check.yml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - content/en/**
+      - .github/workflows/i18n-consistency-check.yml
+  workflow_dispatch:
+
+jobs:
+  consistency-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [ja, de, zh, it, es, ru, fr]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Check consistency
+        id: check-consistency
+        run: |
+          # Set the issue header
+          issue="# i18n Contents Consistency Issue\\n\\n\
+          The following files may have consistency issues with the English version. Please check and update the files.\\n\
+          This issue is created when there is an update to content/en. It compares the git update history to let you know what updates are overdue. The issue should be closed when the update is complete.\\n\\n"
+
+          # Loop through all the files in the English directory
+          for file in content/en/**/*.md; do
+
+            # Get the translated file name and check if it exists
+            i18n_filename=$(echo "$file" | sed -e "s/\/en\//\/${{matrix.language}}\//")
+            if [[ ! -e "$i18n_filename" ]]; then
+              continue
+            fi
+
+            # Get the last updated date of the original file and the translated file
+            original_updated_at=$(date -d "$(git log -1 --format=%cd --date=iso $file)" +%s) 
+            i18n_content_updated_at=$(date -d "$(git log -1 --format=%cd --date=iso $i18n_filename)" +%s)
+
+            # Check if the translated file is updated after the original file
+            if [[ $(($original_updated_at - $i18n_content_updated_at)) -ge 1 ]]; then
+
+              # Get the title of the content
+              content_header=$(echo "$(cat "$file")" | grep -E '^title+' | sort -r | head -n1)
+              content_title=$(echo "$content_header" | sed 's/title: //g')
+
+              # Get the days since the translated file is overdue
+              days_since_overdue_updates=$(($(( $(date +%s) - $original_updated_at))/ 60 / 60 / 24))
+
+              # Get the diff between the original file and the translated file
+              original_last_update_hash=$(git log -1 --format=%H $file)
+              i18n_last_update_hash=$(git log --until i18n_content_updated_at -1 --format=%H)
+              result=$(echo "$(git diff ${i18n_last_update_hash} ${original_last_update_hash} $file)" | sed '1,4 s/^/# /')
+
+              # Add the contents to the issue.md file
+              issue+="<details><summary><b>$content_title</b> ($file)</summary>\\n\\n"
+              issue+="- Original File(en): [$file](https://github.com/$GITHUB_REPOSITORY/blob/master/$file)\\n"
+              issue+="- Translated File(${{ matrix.language}}): [$i18n_filename](https://github.com/$GITHUB_REPOSITORY/blob/master/$i18n_filename)\\n"
+              issue+="- [Diff on GitHub](https://github.com/yuhattor/innersourcecommons.org/compare/$i18n_last_update_hash...$original_last_update_hash)\\n"
+              issue+="- Days since overdue updates: $days_since_overdue_updates days\\n"
+              issue+="\`\`\`diff\\n"
+              issue+="$result"
+              issue+="\\n\`\`\`\\n"
+              issue+="</details>\\n"
+              echo -e "$issue" >> issue.md
+              issue=""
+            fi
+          done
+      - name: Create Issue
+        run: | 
+          # Declare the flags
+          declare -A flags=(
+            ["ja"]="🇯🇵 Japanese"
+            ["de"]="🇩🇪 German"
+            ["zh"]="🇨🇳 Chinese"
+            ["it"]="🇮🇹 Italian"
+            ["es"]="🇪🇸 Spanish"
+            ["ru"]="🇷🇺 Russian"
+            ["fr"]="🇫🇷 French"
+          )
+
+          # Set the issue title
+          issue_title="${flags[${{matrix.language}}]}: Content Consistency Issue"
+
+          # Get the existing issue ID
+          existing_issue_id=$(gh issue list -S "state:open type:issue title:$issue_title" | cut -f1)
+
+          # If the issue.md file exists, create a new issue or comment on the existing issue
+          if [ -f issue.md ]; then
+            if expr "$existing_issue_id" : '^[0-9]*$' >/dev/null; then
+              gh issue comment "$existing_issue_id" -F issue.md -R $GITHUB_REPOSITORY
+            else
+              gh issue create -t "$issue_title" -F issue.md -R $GITHUB_REPOSITORY -l documentation
+            fi
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n-consistency-check.yml
+++ b/.github/workflows/i18n-consistency-check.yml
@@ -1,18 +1,13 @@
 name: i18n check consistency and notify on GitHub Issues
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - content/en/**
-      - .github/workflows/i18n-consistency-check.yml
   pull_request:
     branches:
       - master
     paths:
-      - content/en/**
       - .github/workflows/i18n-consistency-check.yml
+  schedule:
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As I mentioned on Slack, I added language consistency check GitHub Action.

> The first is maintaining consistency with content updated in English. We think this can be resolved by implementing a GitHub Actions workflow in the future to automatically detect and notify of any update in each language.

This action compares the git log and notifies members if the English version has been updated but not each language. An example is as follows
https://github.com/yuhattor/innersourcecommons.org/issues/6
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/15963767/209676234-98c56ae4-fae2-412b-aebc-9fb0307be946.png">

For now, it is triggered when there is a change under `content/en`. However, I would like to reduce the frequency to once a week or once every two weeks as we move forward, as it is not good to have updates too often.