### PR TITLE
Add and update scripts and instruction for i18n contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing
+
 Contributions to this repo are welcome. Please follow the following guidelines:
 
 ## Forking
@@ -9,3 +10,4 @@ Contributions to this repo are welcome. Please follow the following guidelines:
 * Commit to your fork.
 * Follow the GitHub Guidelines on creating a pull request.
 * Please be as descriptive as necessary in your PR.
+* For i18n contributors, we recommend reading [the instructions on how it works](i18n.md).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ To add a new logo/org to the Stories page, please fill in [this issue][issue-tem
 
 ## i18n Support
 
-[innersourcecommons.org][] supports i18n. Currently, we are in the process of adding languages, but local instructions can be found [here](i18n.md).
+To increase familiarity with the InnerSource concept among non-English speakers, the ISC website provides pages in multiple languages. These translations are completed by volunteer contributors and are not immediately available for all pages. As a result, there may be a significant amount of content that is currently in the process of being translated. We welcome any contributions to the translation effort!
+
+Instructions can be found [here](i18n.md).
 
 [innersourcecommons.org]: https://innersourcecommons.org
 [hugo]: https://gohugo.io/getting-started/installing/

--- a/i18n.md
+++ b/i18n.md
@@ -1,37 +1,75 @@
-# Internationalization (i18n) API
+# i18n Support
 
-## Local run for other Languages (Advanced)
+To increase familiarity with the InnerSource concept among non-English speakers, the ISC website provides pages in multiple languages. These translations are completed by volunteer contributors and are not immediately available for all pages. As a result, there may be a significant amount of content that is currently in the process of being translated. We welcome any contributions to the translation effort.
 
-In addition to the above instllation and local run section, the following settings must be made to see translations in other languages.
-English is the primary language in ISC and all updates are first updated in English.
-So when you select English as your main locale and look at the contents under `content/en/`, you will see all the information.
+## About i18n.sh script
 
-Since we want non-English speakers to become more familiar with the InnerSrouce concept, the ISC site also offers pages in several languages.
-These translations are provided by volunteer contributors, and not all pages are translated in real time.
-Therefore, there will be a lot of content that is still in the process of being translated in some languages. We welcome you to contribute to the translation!
+To assist you in your translation work, we have prepared commands to run locally.
+Please run the [i18n.sh](i18n.sh) script after reading this document.
 
-However, in order for Hugo to successfully work pages for each language, you need to prepare all the files, not just create translation files for some pages. Otherwise Hugo will return a 404 error. Nevertheless, it would not be a good administrative practice to keep a copy of all the untranslated English files for each language.
-Therefore, at this phase, we use GitHub Actions to copy untranslated data from `content/en` to the content directory of each language when the site is updated, and place only translated files in the repository.
+### Preparation for local editing
 
-To copy the missing files for local testing, run the following command
-The copied files will automatically go into .gitignore, so you won't accidentally commit a bunch of files.
+Pre-requisites
 
-```bash
-# Create local copy for debug
-for i in de es fr it ja ru zh; do
-  rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore;
-  gsed -i "s/^.\{37\} /$i\//g" content/.gitignore;
-  gsed -i '/total size\|file list/d' content/.gitignore;
-done
+- `gsed` command installation (*Optional for MacOS users)
+
+  ```sh
+  brew install gnu-sed
+  ```
+
+- Grant execute permission
+  You need to run the command to grant execute permission to the i18n.sh script file. This is necessary in order to run the script.
+
+  ```sh
+  chmod +x i18n.sh
+  ```
+
+- Read help
+  This command displays the help message for the i18n.sh script.
+
+  ```sh
+  ./i18n.sh --help/-h
+  ```
+
+### Obtaining a local copy of the necessary files
+
+In order for Hugo to properly work with pages in different languages, it is necessary to prepare all necessary files, rather than just creating translation files for certain pages. If this is not done, Hugo will return a 404 error.
+
+However, it is not practical to maintain copies of all untranslated English files for each language in the repository. To address this issue, we use GitHub Actions to copy untranslated data from the content/en directory to the content directory of each language (content/<`locale code`>) when the site is updated, and placing only translated files in the repository.
+
+While the full files are not required for the site to function properly, they may be necessary for local runs. To copy and clean untranslated files for a local run, use the following command. The copied files will be automatically added to the .gitignore file to prevent accidental commits of a large number of files.
+
+```sh
+./i18n.sh copy  
 ```
 
-When you are done editing, the files you just downloaded that are untranslated and unnecessary should still be in `content/.gitignore'.
-the following set of commands will allow you to erase those files under each language's content directory.
+### Cleaning up the local copy of the files
 
-```bash
-# Delete local Copy for debug
-for f in $(cat content/.gitignore); do 
-  rm "content/$f"
-done
-rm content/.gitignore;
+After completing your edits, the untranslated and unnecessary files that you copied should still be listed in the content/.gitignore file. The following set of commands will allow you to delete these files from the content directory for each language.  Note: If you have completed a translation and the file path is still listed in the content/.gitignore file, your translated file will also be deleted. Be sure to update the content/.gitignore file before running the clean-up command to avoid this issue.
+
+```sh
+./i18n.sh clean 
 ```
+
+## How the code works
+
+Despite its initial appearance of complexity, the underlying code of i18n.sh is relatively straightforward. In the event that i18n.sh experiences issues or for a deeper understanding of its function, the main components of the code can be examined individually. These individual code sections can be run independently for further analysis.
+
+- **Create local copy for debug**
+
+  ```sh
+  for i in de es fr it ja ru zh; do
+    rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore
+    gsed -i '/total size\|file list/d' content/.gitignore
+    gsed -i -E "s/^.+\s+(.+)$/$i\/\1/" content/.gitignore
+  done
+  ```
+
+- **Delete local Copy for debug**
+
+  ```sh
+  for f in $(cat content/.gitignore); do 
+    rm "content/$f"
+  done
+  rm content/.gitignore;
+  ```

--- a/i18n.sh
+++ b/i18n.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Get Params
+operation=$1
+
+# Show the help message
+if [ "$operation" = "--help" ] || [ "$operation" = "-h" ] || [ "$operation" = "" ]; then
+	cat <<-EOF
+
+  Usage: i18n.sh [operation]
+  Operations:
+
+    --help/-h:	
+      Show the help message.
+
+    copy:
+      Copy untranslated files from content/en to the content/<LANG> directories and 
+      add them to content/.gitignore to prevent the files from being committed.
+
+    clean:	
+      Delete untranslated files listed in content/.gitignore.
+      WARNING: For files that have been translated, REMOVE them from the series 
+      of deletions by deleting their paths from the local content/.gitignore.
+
+	EOF
+  exit 0
+fi
+
+cat <<-EOF
+To see how it works, run the help command: './i18n.sh --help'
+
+Are you sure you want to proceed? (Yes/No)
+
+EOF
+
+read answer
+
+if [ "$answer" = "Yes" ]; then
+  if [ "$operation" = "copy" ]; then
+    # Copy Operation
+    if which gsed > /dev/null; then
+      echo "hi"
+      for i in de es fr it ja ru zh; do
+        rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore
+        gsed -i '/total size\|file list/d' content/.gitignore
+        gsed -i -E "s/^.+\s+(.+)$/$i\/\1/" content/.gitignore
+      done
+    else
+      # Check the operating system
+      if [ "$(uname)" == "Darwin" ]; then
+        # If the operating system is macOS, stop execution and display a message
+        echo "Please install gsed using 'brew install gnu-sed'"
+        exit 1
+      else
+        rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore
+        sed -i '/total size\|file list/d' content/.gitignore
+        sed -i -E "s/^.+\s+(.+)$/$i\/\1/" content/.gitignore
+      fi
+    fi
+
+  elif [ "$operation" = "clean" ]; then
+    if [ ! -f content/.gitignore ]; then
+      echo "Error: content/.gitignore not found. You need to copy the files first."
+      exit 1
+    fi
+
+	  cat <<-EOF
+
+			After completing your edits, the untranslated and unnecessary files that you copied should 
+			still be listed in the content/.gitignore file. The following this command will clean these 
+			files from the content directory for each language.
+
+			Again, are you sure to clean it? (Yes/No)
+			
+		EOF
+
+    read double_check
+    if [ "$double_check" = "Yes" ]; then
+      # Delete Operation
+      num_lines=$(wc -l < content/.gitignore)
+      i=0
+      for f in $(cat content/.gitignore); do
+        i=$((i + 1))  # progress count
+        printf "Progress: %3d%%\r" "$((i * 100 / num_lines))"
+        rm "content/$f" # File deletion
+      done
+      echo
+      rm content/.gitignore
+    fi
+  else
+    echo "Invalid operation specified. Please specify either copy or clean as the parameter."
+  fi
+else
+  echo "Script terminated."
+fi
+
+


### PR DESCRIPTION
In order to facilitate the translation of the InnerSourceCommons.org website into various languages, we have developed instructions and a script to enable individuals to easily run the site locally. It is important to provide guidance to individuals interested in contributing to this effort, and these resources aim to facilitate this process. By utilizing these instructions and script, individuals will be able to quickly and efficiently begin contributing to the translation of the website.