### PR TITLE
Social: Mastodon verification

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -49,4 +49,7 @@
     {{ end }}
   {{ end }}
 
+  {{ "<!-- Mastodon verification code -->" | safeHTML }}
+  <link href="https://fosstodon.org/@innersource" rel="me">
+
 </head>


### PR DESCRIPTION
Adding a link to the footer with the `rel` parameter would have been enough, but currently there is no icon for Mastodon on the themify icon set.

Because of that, I have chosen the `<link>` method.

With this, the link to the website on our Mastodon account should be shown as verified.

Related issues:
- https://github.com/InnerSourceCommons/InnerSourceMarketing/issues/197

References
- https://docs.joinmastodon.org/user/profile/#verification