### PR TITLE
Devenv: Run locally with docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
+          # When this version is updated, it must be also updated at docker-compose.yml
           hugo-version: '0.80.0'
           extended: true
       - name: Copy the missing files from /content/en for publishing each language site

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ cd innersourcecommons.org
 hugo server
 ```
 
+Alternatively, if you have [Docker][] installed in your machine, you can do the same with docker compose, as shown below.
+
+```sh
+git clone [url]
+cd innersourcecommons.org
+docker compose up -d
+``` 
+
 ## Making changes to specific pages
 
 ### Adding a logo to the Stories page
@@ -46,3 +54,4 @@ Instructions can be found [here](i18n.md).
 [hugo]: https://gohugo.io/getting-started/installing/
 [stories]: https://innersourcecommons.org/stories/
 [issue-template]: https://github.com/InnerSourceCommons/InnerSourceMarketing/issues/new?assignees=&labels=website&template=add-a-new-org-logo-to-the-website.md&title=Add+%5Borganisation+name%5D+logo+to+the+Stories+Page
+[Docker]: https://www.docker.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  hugo:
+    # The version here must be kept in sync with the one used at .github/workflows/main.yml
+    image: klakegg/hugo:0.80.0-ext-ubuntu
+    command: server
+    ports:
+    - "1313:1313"
+    volumes:
+    - .:/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   hugo:
     # The version here must be kept in sync with the one used at .github/workflows/main.yml
     image: klakegg/hugo:0.80.0-ext-ubuntu
-    command: server
+    command: server --appendPort=false --baseURL=/
     ports:
     - "1313:1313"
     volumes:


### PR DESCRIPTION
This commit introduces a docker-compose.yml file so that contributors can run the hugo server locally without having to install hugo, as long as they have Docker installed (there may be also compatible alternatives I am not aware of).

I have used the image https://hub.docker.com/r/klakegg/hugo/#! and kept the base os and version as close as possible to what is used in the deployment GitHub Actions.

Unfortunately this introduces the need to maintain the same information in both places.