### PR TITLE
Adding Brazilian Portuguese settings to innersourcecommons.org

### DIFF
--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -31,6 +31,6 @@ fr:
   contentDir: content/fr
   weight: 3
 pt-br:
-  languageName: Brazilian Portuguese
+  languageName: Português Brasileiro
   contentDir: content/pt-br
   weight: 3

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -30,3 +30,7 @@ fr:
   languageName: Français
   contentDir: content/fr
   weight: 3
+pt-br:
+  languageName: Brazilian Portuguese
+  contentDir: content/pt-br
+  weight: 3

--- a/config/_default/menus.pt-br.yaml
+++ b/config/_default/menus.pt-br.yaml
@@ -1,0 +1,123 @@
+main:
+  - name: Aprender
+    URL: learn
+    weight: 1
+    identifier: learn
+  - name: Livros
+    parent: learn
+    URL: learn/books
+    weight: 2
+  - name: Caminho de Aprendizado
+    parent: learn
+    URL: learn/learning-path
+    weight: 3
+  - name: Padrões
+    parent: learn
+    URL: learn/patterns
+    weight: 4
+  - name: Pesquisa
+    parent: learn
+    URL: learn/research
+    weight: 5
+  - name: Eventos
+    URL: events
+    weight: 2
+  - name: Comunidade
+    identifier: community
+    URL: community
+    weight: 3
+  - name: Histórias
+    URL: stories
+    weight: 4
+  - name: Diretório de Serviços
+    URL: community/services
+    parent: community
+    weight: 2
+  - name: Sobre
+    identifier: about
+    URL: about
+    weight: 5
+  - name: Anúncios
+    URL: about/announcements
+    parent: about
+    weight: 1
+  - name: Diretoria e Governança
+    URL: about/board
+    parent: about
+    weight: 2
+  - name: Membros
+    URL: about/members
+    parent: about
+    weight: 3
+  - name: Patrocinadores
+    URL: about/sponsors
+    parent: about
+    weight: 4
+  - name: Código de Conduta
+    URL: about/codeofconduct
+    parent: about
+    weight: 5
+  - name: Fale Conosco
+    URL: about/contact
+    parent: about
+    weight: 6
+footer_left:
+  - name: Aprender
+    URL: learn
+    weight: 1
+    post: bold
+  - name: Livros
+    URL: learn/books
+    weight: 2
+  - name: Caminho de Aprendizado
+    URL: learn/learning-path
+    weight: 3
+  - name: Padrões
+    URL: learn/patterns
+    weight: 4
+  - name: Pesquisa
+    URL: learn/research
+    weight: 5
+footer_middle:
+  - name: Eventos
+    URL: events
+    weight: 1
+    post: bold
+  - name: Comunidade
+    URL: community
+    weight: 2
+    post: bold
+    pre: _blank
+  - name: Histórias
+    URL: stories
+    weight: 3
+    post: bold
+  - name: Diretório de Serviços
+    URL: community/services
+    weight: 4
+  - name: Anúncios
+    URL: about/announcements
+    weight: 5
+footer_right:
+  - name: Sobre
+    URL: about
+    weight: 1
+    post: bold
+  - name: Diretoria e Governança
+    URL: about/board
+    weight: 2
+  - name: Membros
+    URL: about/members
+    weight: 3
+  - name: Patrocinadores
+    URL: about/sponsors
+    weight: 4
+  - name: Código de Conduta
+    URL: about/codeofconduct
+    weight: 5
+  - name: Fale Conosco
+    URL: about/contact
+    weight: 6
+  - name: Política de Privacidade
+    URL: about/privacy
+    weight: 7

--- a/i18n.sh
+++ b/i18n.sh
@@ -39,7 +39,7 @@ if [ "$answer" = "Yes" ]; then
   if [ "$operation" = "copy" ]; then
     # Copy Operation
     if which gsed > /dev/null; then
-      for i in de es fr it ja ru zh; do
+      for i in de es fr it ja ru zh pt-br; do
         rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore
         gsed -i '/total size\|file list/d' content/.gitignore
         gsed -i -E "s/^.+\s+(.+)$/$i\/\1/" content/.gitignore
@@ -51,7 +51,7 @@ if [ "$answer" = "Yes" ]; then
         echo "Please install gsed using 'brew install gnu-sed'"
         exit 1
       else
-        for i in de es fr it ja ru zh; do
+        for i in de es fr it ja ru zh pt-br; do
           rsync -rv --ignore-existing content/en/ content/$i/ --log-file=content/.gitignore
           sed -i '/total size\|file list/d' content/.gitignore
           sed -i -E "s/^.+\s+(.+)$/$i\/\1/" content/.gitignore

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -1,0 +1,33 @@
+join_slack: "Participe do Slack"
+more_videos: "Mais Vídeos"
+
+# Lista de emails
+join_mailing_list: "Participe da Lista de Emails"
+enter_email: "Digite o Email"
+subscribe: "Inscrever-se"
+
+# Sobre
+about_innersource_commons: |-
+  A InnerSource Commons é a maior comunidade mundial de praticantes de InnerSource. É dedicada à criação e compartilhamento de conhecimento sobre InnerSource, o uso das melhores práticas de código aberto para o desenvolvimento de software dentro dos limites de uma organização.
+about_innersource_commons_history: |-
+  Fundada em 2015, a InnerSource Commons agora apoia e conecta mais de 2000 indivíduos de mais de 750 empresas, instituições acadêmicas e agências governamentais. A InnerSource Commons Foundation foi incorporada em 19 de fevereiro de 2020 e agora é uma instituição de caridade pública 501(c)(3).
+
+# Aprender
+learn_button: Aprender
+
+## Livro
+author: Autor
+publication_date: Data de Publicação
+publisher: Editora
+read_the_book: Leia o livro
+
+## Pesquisa
+read_research_report: Ler Relatório de Pesquisa
+
+## Metadados do Site
+meta_description: A InnerSource Commons é uma comunidade crescente de profissionais com o objetivo de criar e compartilhar conhecimento sobre InnerSource.
+meta_keywords: InnerSource,Código aberto,silo,colaboração
+
+# Licença
+footer_content: |-
+  O site está licenciado sob uma licença CC-BY-SA, a menos que indicado de outra forma.


### PR DESCRIPTION
Added Brazilian Portuguese settings to innersourcecommons.org 

```Related PR```: https://github.com/InnerSourceCommons/InnerSourceLearningPath/pull/549

Hi @fer-correa and @ArmandoGuimaraes, 
Could you check if the machine translation of below files is okay or not? If not, please send PR to ```adding-pt-br-language``` branch:)

- [ ] config/_default/menus.pt-br.yaml
- [ ] i18n/pt-br.yaml

@rrrutledge,
- [ ] Since merging the LearningPath PR now won't break the innersourcecommons.org page, can you have it merged into main or master for now?



So far it is as follows. This screenshot shows a temporary environment that you can easily reproduce on GitHub Codespaces.
1. fork the ```adding-pt-br-language``` branch 
2. Open it on GitHub Codespaces
3. Run the following command in the terminal in your codespace

```bash
. /i18n.sh copy # And please type "Yes"
docker compose up -d
```

4. ```pt-br``` env should be only shown under ```/learn/learning-path``` URL after [the PR](https://github.com/InnerSourceCommons/InnerSourceLearningPath/pull/549) is merged on LearningPath repository

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/15963767/235284517-82ddc76d-4d46-4761-9435-1f0f2a6d4810.png">
