### PR TITLE
removes the second banner

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -55,18 +55,6 @@
   </div>
 </header>
 {{ "<!-- /navigation -->" | safeHTML }}
-<section class="notice bg-transperant">
-  <div class="container">
-    <div class="row align-items-center">
-      <div class="col-md-12 text-center text-dark">
-        <i class="ti-announcement mr-2"></i>
-        <a href="https://bit.ly/45QzPkO" class="btn-link ml-1" target="_blank"> The Call for Presenters 
-          </a>
-          for the InnerSource Summit 2023 on November 15-16 is now open! Deadline is September 30 (anywhwere on Earth)!
-      </div>
-    </div>
-  </div>
-</section>
 
 <section class="notice bg-light">
   <div class="container">


### PR DESCRIPTION
Removes the secondary banner from the header. Picture for reference with the banner removed:
![image](https://github.com/InnerSourceCommons/innersourcecommons.org/assets/77273562/e3aaabbd-19b3-49ca-8d90-342f22d130e5)


Closes #625 