### PR TITLE
Fixing wrong dates of the 2023 Summit

### DIFF
--- a/content/en/events/isc-2023.md
+++ b/content/en/events/isc-2023.md
@@ -43,12 +43,9 @@ Formal invoices and receipts can also be provided for sponsors.
 Our summit is planned over multiple time zones so we look forward to seeing you there, no matter where in the world you are sitting. The summit will comprise of 2 x 4 hour sessions, each timed for our community in particular 
 regions. Each session will have a unique set of speakers in two tracks that run simultaneously. One registration covers both sessions, and we hope many of you will join us for both.
 
-**Part 1** is timed for **Europe, Africa, East Coast US, and early birds on the US west coast**: (Wed 16th Nov UTC 3-7pm / CET 4-8pm / EST 10am-2pm / PST 7-11am)
+**Part 1** is timed for **Europe, Africa, East Coast US, and early birds on the US west coast**: (Wed 15th Nov UTC 3-7pm / CET 4-8pm / EST 10am-2pm / PST 7-11am)
 
-**Part 2** is timed for **APAC, Europe, Middle East, & Africa**: (Thur 17th Nov UTC 7:30-11:30am / CET 8:30am -12:30pm / IST 1- 5pm / AEST & CST 6:30 -10:30pm)
-
-
-
+**Part 2** is timed for **APAC, Europe, Middle East, & Africa**: (Thur 16th Nov UTC 7:30-11:30am / CET 8:30am -12:30pm / IST 1- 5pm / AEST & CST 6:30 -10:30pm)
 
 ### Speaker Bios
 


### PR DESCRIPTION
It said 16/17 November, which it should be 15/16.