### PR TITLE
feat(events): Blog post for events

### DIFF
--- a/content/en/events/meetup-2024-02-27.md
+++ b/content/en/events/meetup-2024-02-27.md
@@ -5,7 +5,7 @@ redirect: "https://bit.ly/ISCSAP"
 image: "/images/events/meetup-2024-02-27.png"
 date: 2024-02-27
 publishDate: 2024-02-07
-
+blogPostLink: https://community.sap.com/t5/technology-blogs-by-sap/cross-product-architecture-embracing-conway-s-law-for-better-software/ba-p/13648600
 ---
 
 This talk will look at the "Cross-Product Architecture" collaboration model which some consider SAP's largest InnerSource project involving 3,000+ architects and experts across numerous organizations.

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -47,6 +47,8 @@
               <a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-primary btn-sm mr-md-1">Open Event</a>
               {{ if .Params.youtubeLink }}
                 <a href="{{ .Params.youtubeLink }}" target="_blank" class="btn btn-secondary btn-sm mt-sm-1 mt-md-0">Watch Recording</a>
+              {{ else if .Params.blogPostLink }}
+                <a href="{{ .Params.blogPostLink }}" target="_blank" class="btn btn-secondary btn-sm mt-sm-1 mt-md-0">Read the blog post</a>
               {{ end }}
             </div>
           </div>


### PR DESCRIPTION
This commit adds the alternative to provide a link to a blog post related to an event, when the recording is not available.

As the space in the UI cannot currently accommodate an additional button, it is either a recording, or a blog post.

The feature is used in the community call from 2024-02-27.

cc @OliveCannon .