### PR TITLE
refactor: removes aliases from announcements

### DIFF
--- a/content/en/about/announcements/2023-06-new-members.md
+++ b/content/en/about/announcements/2023-06-new-members.md
@@ -5,8 +5,6 @@ image: "/images/about/announcements/2023-06-new-members-announcement.png"
 date: 2023-06-12
 featured: false
 type: "announcements"
-aliases:
-    - /about/announcements/2023-06-new-board-and-officers
 ---
  
 June, 2023

--- a/content/en/about/announcements/2023-08-new-executive-director.md
+++ b/content/en/about/announcements/2023-08-new-executive-director.md
@@ -5,8 +5,6 @@ image: "/images/about/announcements/2023-08-new-executive-director-announcement.
 date: 2023-08-02
 featured: false
 type: "announcements"
-aliases:
-    - /about/announcements/2023-08-new-executive-director
 ---
  
 August 2023


### PR DESCRIPTION
A workaround for #521 until we find a permanent fix. Seems that this only happens if aliases are used for announcements