### PR TITLE
Code of Conduct reports may go to single board members

### DIFF
--- a/content/en/about/codeofconduct.md
+++ b/content/en/about/codeofconduct.md
@@ -53,7 +53,9 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-board@innersourcecommons.org. All complaints will be reviewed and investigated promptly and fairly.
+board@innersourcecommons.org
+Report may also go to any single [board member](https://innersourcecommons.org/about/board/).
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
* Read [the document](https://github.com/InnerSourceCommons/innersourcecommons.org/blob/48049473f683fee5bf65d8ad91b48ca80c0db34f/content/en/about/codeofconduct.md).
* This change came from [this discussion](https://github.com/InnerSourceCommons/foundation/pull/434#discussion_r1698249433).