### PR TITLE
fix: Scaling content on Learn page

### DIFF
--- a/content/en/learn/scaling/_index.md
+++ b/content/en/learn/scaling/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Scaling InnerSource"
 subtitle: "How can I scale InnerSource?"
+description: "A mindmap to help you use different parts of the InnerSource Commons material to scale InnerSource"
 type: "community"
 image: "images/learn/patterns.png"
 weight: 1


### PR DESCRIPTION
This commit fixes an issue on the `/learn` page introduced with the mindmap for scaling.

Acording to my tests:
1. If a folder does not have a `_index.md` file, every file under the folder will generate a section under the `/learn` page. in This way, both files, `mindmap.md` and `markmap_content.md` were generating content. To fix this, I renamed `mindmap.md` to `_index.md`.
2. When a file does not mave a `description` property in the frontmatter block, it will use the content of the file as description. To fix this I added a `description` property to `mindmap.md` (now renamed to `_index.md`.

Result:
<img width="896" alt="image" src="https://github.com/user-attachments/assets/993f2259-ef80-4574-b027-af527d8fc94f">

Related issues
- https://github.com/InnerSourceCommons/innersourcecommons.org/pull/902#issuecomment-2422746281