### PR TITLE
Create Hugo config to override date field order

### DIFF
--- a/hugo.json
+++ b/hugo.json
@@ -1,0 +1,8 @@
+{
+    "frontmatter": {
+       "date": [
+          "report_publish_date",
+          ":default"
+       ]
+    }
+ }


### PR DESCRIPTION
In the research page we use the Date parameter to define the other to show to the users. 
The issue is that we do not have all reports in the localization folders (e.g. `pt-br`), and we have a script to copy that content from the `en` folder. So, what happens is that it is showing the `2023` first than the `2024`.
Hugo supports to override the order of the fields that it looks to define the value of the `Date` parameter.
This PRs create the Hugo's configuration file, adding to check first if there is a field in `frontmatter` called `report_publish_date` to define the `Date` value.

Tested locally with both pages that uses `Date` value for order: `announcements` and `research` 