### PR TITLE
feat: add translation to button "read research"

### DIFF
--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -17,7 +17,7 @@
             {{ if and (now.Before (time .Params.report_publish_date)) (now.After (time .Params.survey_closing_date)) }}
               <a href="{{.Permalink}}" class="btn btn-primary btn-sm">Coming Soon</a>
             {{ else if (now.After (time .Params.report_publish_date)) }}
-              <a href="{{.Permalink}}" class="btn btn-primary btn-sm">Read Research Report</a>
+              <a href="{{.Permalink}}" class="btn btn-primary btn-sm">{{ T "read_research_report" }}</a>
             {{ else }}
               <a href="{{.Permalink}}" class="btn btn-primary btn-sm">Take Survey</a>
             {{ end }}


### PR DESCRIPTION
In the list of research page, the button to read it was missing the translation. The translation was already created, but the template was not using it.
This PR changes the template to get the string from the translation, instead of the hardcoded.

Print from `pt-br` page: 
`before`
<img width="1209" alt="Screenshot 2024-10-28 at 08 20 36" src="https://github.com/user-attachments/assets/984d3237-33ad-47d4-8582-7f959f9eaf21">

`after`
<img width="1203" alt="Screenshot 2024-10-28 at 08 20 06" src="https://github.com/user-attachments/assets/3d77b987-d8f2-4333-bb24-1448e5a96dd7">

