### PR TITLE
2024-10 Board Meeting Terse Notes 

### DIFF
--- a/content/en/about/board/2024-10-31.md
+++ b/content/en/about/board/2024-10-31.md
@@ -8,15 +8,15 @@ title: '2024-10-31'
 
 * Call to order: 2024-10-31, 08:20 PM UTC
 * Adjourned: TBD
-* Next Meeting: Nov 28, 2024 02:00 PM UTC
+* Next Meeting: Nov 26, 2024 02:00 PM UTC
 
 ### Roll call
 
 #### Directors and Officers Present
 
-#### Directors and Officers Absent
+* Daniel Izquierdo-Cortazar (President, Proxy for Yuki Hattori)
 
-* Yuki Hattori  (Vice-President, Proxied by Daniel Izquierdo-Cortazar)
+#### Directors and Officers Absent
 
 ### Votes Taken
 

--- a/content/en/about/board/2024-10-31.md
+++ b/content/en/about/board/2024-10-31.md
@@ -1,0 +1,23 @@
+---
+layout: page
+show_meta: false
+title: '2024-10-31'
+---
+
+### Date and Time of Meeting
+
+* Call to order: 2024-10-31, 08:20 PM UTC
+* Adjourned: TBD
+* Next Meeting: Nov 28, 2024 02:00 PM UTC
+
+### Roll call
+
+#### Directors and Officers Present
+
+#### Directors and Officers Absent
+
+* Yuki Hattori  (Vice-President, Proxied by Daniel Izquierdo-Cortazar)
+
+### Votes Taken
+
+None


### PR DESCRIPTION
This pull request adds a new meeting minutes page for the board meeting held on October 31, 2024. The page includes details such as the date and time of the meeting, roll call of directors and officers present and absent, and notes that no votes were taken during the meeting.