### PR TITLE
2024-11 Board Meeting Terse Notes

### DIFF
--- a/content/en/about/board/2024-11-28.md
+++ b/content/en/about/board/2024-11-28.md
@@ -1,0 +1,43 @@
+---
+layout: page
+show_meta: false
+title: '2024-11-26'
+---
+
+### Date and Time of Meeting
+
+* Call to order: 2024-11-26, 14:08 UTC
+* Adjourned: 14:41 UTC
+* Next Meeting: 2024-12-19, 9:00 AM UTC 
+
+### Roll call
+
+#### Directors and Officers Present
+
+* Yuki Hattori (Vice-President)
+* Tom Sadler (Treasurer) (proxy for Georg Grütter)
+* Clare Dillon (proxy for Daniel Izquierdo-Cortazar)
+* Daniel Izquierdo-Cortazar (President) (joined at 14:22 UTC)
+
+#### Directors and Officers Absent
+
+* Matt Cobby (Secretary)
+* Sebastian Spier
+* Katie Schueths
+* Danese Cooper
+
+#### Guests Present
+
+* Lori Landesman
+
+### Votes Taken
+
+Motion: The board would formally like to offer everyone involved in organizing and running the InnerSource summit our thank and congratulations on another fantastic event!
+
+Approved (5 votes):
+
+* Yuki Hattori
+* Tom Sadler
+* Georg Grütter
+* Clare Dillon
+* Daniel Izquierdo-Cortazar


### PR DESCRIPTION
This pull request includes changes to add the meeting minutes for the board meeting held on November 26, 2024. The new file documents the date and time of the meeting, attendees, and votes taken.