### PR TITLE
feat: add contact prompt under slack link

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -48,6 +48,9 @@ title: "Community"
     <div class="row d-flex justify-content-center">
         <a href="/slack" class="btn btn-primary btn-sm"><img src="/images/slack.png" class="slack-tiny mr-2"/>Join Slack</a>
     </div>
+    <div class="row d-flex justify-content-center">
+      <p class="mt-4">You can also email us at <a href="mailto:info@innersourcecommons.org">info@innersourcecommons.org</a> if you have trouble joining. </p>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
Added it as a direct email prompt instead of redirecting to the contact page as the only contact action a user could really take from the Contact page is email and Slack. 

![image](https://github.com/user-attachments/assets/b818676b-84e8-4dce-902d-47002930f959)


Closes #942 