### PR TITLE
2024-12 Board Meeting Terse Notes

### DIFF
--- a/content/en/about/board/2024-12-19.md
+++ b/content/en/about/board/2024-12-19.md
@@ -1,0 +1,33 @@
+---
+layout: page
+show_meta: false
+title: '2024-12-19'
+---
+
+### Date and Time of Meeting
+
+* Call to order: 2024-12-19, 9:05 UTC
+* Adjourned: 9:59 UTC
+* Next Meeting: TBC
+
+### Roll call
+
+#### Directors and Officers Present
+
+* Matt Cobby (Secretary) 
+* Georg Grütter (Assistant Treasurer) 
+* Yuki Hattori  (Vice-President)
+* Daniel Izquierdo-Cortazar (President)
+* Tom Sadler (Treasurer)
+
+#### Directors and Officers Absent
+
+* Katie Schueths (Assistant Secretary)
+* Clare Dillon
+* Sebastian Spier 
+* Danese Cooper
+* Russel Rutledge (Executive Director)
+
+### Votes Taken
+
+None


### PR DESCRIPTION
This PR adds the terse notes for our December 24 board meeting.