### PR TITLE
chore: remove the twitter feed embed

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -109,11 +109,10 @@ title: "InnerSource Commons"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Stay Connected</p>
         <p class="mb-4">Most of the action in the community happens on our <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Slack Channel</a>. You can also keep informed about the InnerSource Commons news, events and activities by signing up to our newsletter below, follow us on <a href="https://twitter.com/InnerSourceOrg">Twitter</a> and <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, and subscribing to our <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube Channel</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Sign up to our newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/en/about/contact.md
+++ b/content/en/about/contact.md
@@ -25,11 +25,10 @@ type: wide
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Stay in Touch</p>
         <p class="mb-4">Most of the action in the community happens on our <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Slack Channel</a>. You can also keep informed about the InnerSource Commons news, events and activities by signing up to our newsletter below, follow us on <a href="https://twitter.com/InnerSourceOrg">Twitter</a> and <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, and subscribing to our <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube Channel</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Sign up to our newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -175,11 +175,10 @@ title: "Community"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Stay Connected</p>
         <p class="mb-4">Most of the action in the community happens on our <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Slack Channel</a>. You can also keep informed about the InnerSource Commons news, events and activities by signing up to our newsletter below, follow us on <a href="https://twitter.com/InnerSourceOrg">Twitter</a> and <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, and subscribing to our <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube Channel</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Sign up to our newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -94,11 +94,10 @@ title: "InnerSource Commons"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Rester Connecté</p>
         <p class="mb-4">La plupart des activités de la communauté se déroulent sur le <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1l4a602b6-DKD0B0Y8~WE4aDf~o1xCRw">Canal Slack </a>. Vous pouvez également vous tenir au courant des nouvelles, des évènements et des activités d'InnerSource Commons en vous inscrivant à notre bulletin ci-dessous, en nous suivant sur <a href="https://twitter.com/InnerSourceOrg">Twitter</a> et <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, et en vous abonnant sur notre <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Chaine YouTube</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Rejoignez notre newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/fr/about/contact.md
+++ b/content/fr/about/contact.md
@@ -25,11 +25,10 @@ type: wide
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Rester en contact</p>
         <p class="mb-4">La plupart des actions de la communauté se déroulent sur notre <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1l4a602b6-DKD0B0Y8~WE4aDf~o1xCRw">Canal Slack</a>. Vous pouvez également vous tenir au courant des nouvelles, des événements et des activités d'InnerSource Commons en vous inscrivant à notre bulletin ci-dessous, et en nous suivant sur <a href="https://twitter.com/InnerSourceOrg">Twitter</a> et <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, et s'abonner à notre <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Chaine YouTube</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Rejoignez notre newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/fr/community/_index.md
+++ b/content/fr/community/_index.md
@@ -172,11 +172,10 @@ title: "Communauté"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Gardons le contact</p>
         <p class="mb-4">La plupart de la vie de la communauté se déroule sur notre <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1l4a602b6-DKD0B0Y8~WE4aDf~o1xCRw">Canal Slack</a>. Vous pouvez également vous tenir au courant des nouvelles, des événements et des activités d'InnerSource Commons en vous inscrivant à notre bulletin ci-dessous, en nous suivant sur <a href="https://twitter.com/InnerSourceOrg">Twitter</a> et <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, at en suivant notre <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Chaine YouTube </a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Rejoignez notre newslette</p>
         {{< contact-form >}}
       </div>

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -91,12 +91,11 @@ title: "InnerSource Commons"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">最新情報はこちら</p>
         <p class="mb-4">
         コミュニティ活動のほとんどは、<a href="https://innersourcecommons.org/slack/">Slack</a> で行われています。また、メールの定期購読や、 <a href="https://twitter.com/InnerSourceOrg">Twitter</a>、 <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a> のフォロー、<a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube</a>チャンネルの登録やによって、InnerSource Commons のニュース、イベントについての情報を取得することができます。</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">ニュースレターを定期購読する</p>
         {{< contact-form >}}
       </div>

--- a/content/ja/about/_index.md
+++ b/content/ja/about/_index.md
@@ -91,12 +91,11 @@ title: "InnerSource Commons"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">最新情報はこちら</p>
         <p class="mb-4">
         コミュニティ活動のほとんどは、<a href="https://innersourcecommons.org/slack//">Slack</a> で行われています。また、メールの定期購読や、 <a href="https://twitter.com/InnerSourceOrg">Twitter</a>、 <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a> のフォロー、<a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube</a>チャンネルの登録やによって、InnerSource Commons のニュース、イベントについての情報を取得することができます。</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">ニュースレターを定期購読する</p>
         {{< contact-form >}}
       </div>

--- a/content/ja/community/_index.md
+++ b/content/ja/community/_index.md
@@ -155,12 +155,11 @@ title: "コミュニティ"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">最新情報はこちら</p>
         <p class="mb-4">
         コミュニティ活動のほとんどは、<a href="https://innersourcecommons.org/slack//">Slack</a> で行われています。また、メールの定期購読や、 <a href="https://twitter.com/InnerSourceOrg">Twitter</a>、 <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a> のフォロー、<a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">YouTube</a>チャンネルの登録やによって、InnerSource Commons のニュース、イベントについての情報を取得することができます。</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">ニュースレターを定期購読する</p>
         {{< contact-form >}}
       </div>

--- a/content/pt-br/_index.md
+++ b/content/pt-br/_index.md
@@ -92,11 +92,10 @@ title: "InnerSource Commons"
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+        <p class="h2 section-title">Fique Conectado</p>
+          <p class="mb-4">A maior parte das ações na comunidade acontece em nosso <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Canal do Slack</a>. Você também pode se manter informado sobre as novidades, eventos e atividades da InnerSource Commons assinando nossa newsletter abaixo, nos seguindo no <a href="https://twitter.com/InnerSourceOrg">Twitter</a> e no <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, e se inscrevendo em nosso <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Canal do YouTube</a>.</p>
       </div>
       <div class="col-md-5 offset-md-1">
-        <p class="h2 section-title">Fique Conectado</p>
-            <p class="mb-4">A maior parte das ações na comunidade acontece em nosso <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Canal do Slack</a>. Você também pode se manter informado sobre as novidades, eventos e atividades da InnerSource Commons assinando nossa newsletter abaixo, nos seguindo no <a href="https://twitter.com/InnerSourceOrg">Twitter</a> e no <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, e se inscrevendo em nosso <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Canal do YouTube</a>.</p>
         <p class="h3 section-title">Cadastre-se em nossa newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/pt-br/about/contact.md
+++ b/content/pt-br/about/contact.md
@@ -25,11 +25,10 @@ type: wide
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Mantenha-se em Contato</p>
         <p class="mb-4">A maioria das atividades da comunidade acontece em nosso <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">canal do Slack</a>. Você também pode se manter informado sobre as novidades, eventos e atividades da InnerSource Commons assinando nossa newsletter abaixo, nos seguindo no <a href="https://twitter.com/InnerSourceOrg">Twitter</a> e no <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, e se inscrevendo em nosso <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">canal do YouTube</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Cadastre-se em nossa newsletter</p>
         {{< contact-form >}}
       </div>

--- a/content/pt-br/community/_index.md
+++ b/content/pt-br/community/_index.md
@@ -178,11 +178,10 @@ as as discussões em nosso canal Slack seguem a <a href="https://www.chathamhous
   <div class="container section-small shadow rounded-lg px-4 bg-light">
     <div class="row align-items-center justify-content-center text-center text-md-left">
       <div class="col-lg-5 col-md-4 mb-4 mb-md-0">
-        <a class="twitter-timeline" data-height="500" data-dnt="true" href="https://twitter.com/InnerSourceOrg?ref_src=twsrc%5Etfw"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-      <div class="col-md-5 offset-md-1">
         <p class="h2 section-title">Mantenha-se Conectado</p>
         <p class="mb-4">A maioria das atividades da comunidade acontece no nosso <a href="https://join.slack.com/t/innersourcecommons/shared_invite/zt-1msf8vcqu-fYEHcyI1l4eSPq6rGprMXA">Canal Slack</a>. Você também pode se manter informado sobre as notícias, eventos e atividades da InnerSource Commons assinando nossa newsletter abaixo, nos seguindo no <a href="https://twitter.com/InnerSourceOrg">Twitter</a> e <a href="https://www.linkedin.com/company/innersourcecommons">LinkedIn</a>, e se inscrevendo em nosso <a href="https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA">Canal no YouTube</a>.</p>
+      </div>
+      <div class="col-md-5 offset-md-1">
         <p class="h3 section-title">Cadastre-se em nossa newsletter</p>
         {{< contact-form >}}
       </div>


### PR DESCRIPTION
Removed the twitter feed embed. Had to do a slight redesign of the Stay in touch section as it looked weird without the embed. Will look like this after this is merged: 
![image](https://github.com/user-attachments/assets/949a1058-e861-49ef-859d-67d934c7bb55)

Closes #944 