### PR TITLE
hotfix: only load youtube videos where theyre shown

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "InnerSource Commons"
+fetchYoutubeVideos: true
 ---
 
 

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "InnerSource Commons"
+fetchYoutubeVideos: true
 ---
 
 

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "InnerSource Commons"
+fetchYoutubeVideos: true
 ---
 
 

--- a/content/ja/about/_index.md
+++ b/content/ja/about/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "InnerSource Commons"
+fetchYoutubeVideos: true
 ---
 
 

--- a/content/pt-br/_index.md
+++ b/content/pt-br/_index.md
@@ -1,5 +1,6 @@
 ---
 title: "InnerSource Commons"
+fetchYoutubeVideos: true
 ---
 
 <section class="banner banner-head">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -68,6 +68,8 @@
   });
 </script>
 {{ end }}
+
+{{ if .Params.fetchYoutubeVideos }}
 <script>
 	$('#youmax').youmax({
 	apiKey:'AIzaSyCTmhVwOZhhT1WceQm9MobWFuJIA6lI-Dw',
@@ -85,6 +87,7 @@ $(function(){
 });
 </script>
 
+{{ end }}
 <!-- Google Analytics compliant with GDPR -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-H7179Q3Y3T"></script>
 <script>


### PR DESCRIPTION
The YouTube API was getting called on every single page, rather than just the home page where they're actually shown. This resulted in hundreds of unnecessary  API calls leading to the 10 000 calls quota per day being reached

This likely will successfully close  #964 but in the case of having 10k+ visits of the home page we would also need to cache the videos rather than load them on each page refresh. 