### PR TITLE
hotfix: change version to fix learning page

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           # When this version is updated, it must be also updated at docker-compose.yml
-          hugo-version: '0.142.0'
+          hugo-version: '0.133.1'
           extended: true
       - name: Copy the missing files from /content/en for publishing each language site
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: Innersourcecommons
 services:
   server:
     # The version here must be kept in sync with the one used at .github/workflows/main.yml
-    image: hugomods/hugo:base-0.142.0
+    image: hugomods/hugo:base-0.133.1
     command: server -D
     volumes:
       - ./:/src


### PR DESCRIPTION
There seems to have been something done between hugo versions 131.1 and 134 that breaks the display. I have set the version to 131.1 to avoid that. I'd have to dig into  the changelog when I get some time and identify what the breaking issue is so we can resolve it and update to the latest version (not urgent) https://github.com/gohugoio/hugo/releases?page=3 
Closes #971 