### PR TITLE
fix: only fetch youtube links once

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -72,7 +72,7 @@
 {{ if .Params.fetchYoutubeVideos }}
 <script>
 	$('#youmax').youmax({
-	apiKey:'AIzaSyDyTr4jpR0yAHv6y1VBiU2kvA2OZyfG2HA',
+	apiKey:'AIzaSyAarbxeg1eOcMvxTD2Px_G3OhmDQD9N2EE',
 	youTubeChannelURL: "https://www.youtube.com/channel/UCoSPSd6Or4F_vpjo4SmyoEA",
 	youmaxDefaultTab: "UPLOADS",
 	youmaxColumns: 3,

--- a/static/plugins/youmax/youmax.js
+++ b/static/plugins/youmax/youmax.js
@@ -74,9 +74,10 @@ var youmax_global_options = {};
 
     },
 
-    showUploads = function(response) {
+    showUploads = function() {
         $('#youmax-video-list-div').empty();
-
+        let response = JSON.parse(sessionStorage.getItem("youtubeResponse"));
+        console.log(response);
         var nextPageToken = response.nextPageToken;
         var $youmaxLoadMoreDiv = $('#youmax-load-more-div');
         youmaxColumns = youmax_global_options.youmaxColumns;
@@ -104,19 +105,31 @@ var youmax_global_options = {};
     },
 
     getUploads = function() {
-        let channelId = youmax_global_options.youTubeChannelURL.split('/').pop();
-        var apiUploadURL = "https://www.googleapis.com/youtube/v3/search?key=" + youmax_global_options.apiKey + "&channelId="+ channelId +"&part=snippet,id&order=date&maxResults=" + youmax_global_options.maxResults;
+        let response = JSON.parse(sessionStorage.getItem("youtubeResponse"));
+        if (!(location.hostname === "localhost" || location.hostname === "127.0.0.1")){
+            if(!response){
+                console.log('gonna call');
+                let channelId = youmax_global_options.youTubeChannelURL.split('/').pop();
+                var apiUploadURL = "https://www.googleapis.com/youtube/v3/search?key=" + youmax_global_options.apiKey + "&channelId="+ channelId +"&part=snippet,id&order=date&maxResults=" + youmax_global_options.maxResults;
+        
+                $.ajax({
+                    url: apiUploadURL,
+                    type: "GET",
+                    async: true,
+                    cache: true,
+                    dataType: 'jsonp',
+                    success: function(response) {
+                        sessionStorage.setItem("youtubeResponse", JSON.stringify(response));
+                        showUploads(response);
+                    },
+                    error: function(html) { alert(html); },
+                    beforeSend: setHeader
+                });
+            } else {
+                showUploads();
+            }
+        }
 
-        $.ajax({
-            url: apiUploadURL,
-            type: "GET",
-            async: true,
-            cache: true,
-            dataType: 'jsonp',
-            success: function(response) { showUploads(response);},
-            error: function(html) { alert(html); },
-            beforeSend: setHeader
-        });
     },
 
     $.fn.youmax = function(options) {


### PR DESCRIPTION
Youtube links will now be fetched only once per session so if the user refreshes the page it wont make a second call to the API. This is done due to us reaching the 24h hour 10 000 calls quota too fast and videos not being able to be displayed. Also the fetch would be made only on the website, on localhost it wont get the videos as to not exhaust the quota any further. 