### PR TITLE
Update Siemens story + Upgrade GHA Link Checker PRs

### DIFF
--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -15,13 +15,13 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v32
+        uses: tj-actions/changed-files@v46
 
       - name: Filter markdown files only
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "MARKDOWN_FILES=$md_files" >> $GITHUB_ENV
 
       - name: Restore lychee cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}

--- a/content/en/stories/_index.md
+++ b/content/en/stories/_index.md
@@ -210,7 +210,8 @@ aliases:
       {{< /company >}}
       {{< company name="Shutterstock" image="/images/logos/shutterstock.png" article="https://panelpicker.sxsw.com/vote/89929" >}}
       {{< /company >}}
-      {{< company name="Siemens" image="/images/logos/siemens.png" article="https://jfrog.com/blog/creating-an-inner-source-hub-at-siemens/" >}}
+      {{< company name="Siemens" image="/images/logos/siemens.png" video="https://youtu.be/BbA0qG958s0?si=zAX7dVMAEH6t31Jk" article="https://blog.siemens.com/2023/12/unlocking-collaboration-how-inner-source-transformed-the-way-we-develop-software-at-siemens/" >}}
+      Social Coding at Siemens: Applying best practices from Open Source internally. Working openly and transparently in a collaborative, community-centric way. Defining authority through knowledge and involvement.
       {{< /company >}}
       {{< company name="Skyscanner" image="/images/logos/skyscanner.png" article="https://github.com/customer-stories/skyscanner" >}}
       {{< /company >}}


### PR DESCRIPTION
I noticed that the article URL for the Siemens story was broken.
See https://innersourcecommons.org/stories/

Siemens recently presented about their Social Coding approach at FOSS Backstage. Therefore I knew about other more current material that we can link here.

What I changed:

- add new article link (the [old one](https://jfrog.com/blog/creating-an-inner-source-hub-at-siemens/) was no longer reachable)
- add video describing the Social Coding approach (the recording from FOSS Backstage)
- add a brief description of their definition of Social Coding (based on the slides from FOSS Backstage)

Will try to get somebody from Siemens to review this change, to make sure that we are representing this correctly here.

/cc @deveaud-m @fgreinacher