### PR TITLE
hotfix: fix how events look

### DIFF
--- a/content/en/events/isc-2024.md
+++ b/content/en/events/isc-2024.md
@@ -3,33 +3,10 @@ title: 'InnerSource Summit 2024'
 image: "/images/events/summit-2024.png"
 date: 2024-11-20
 publishDate: 2024-07-10
-showImageInSinglePage: false
 bigHeading: true
 ---
-<nav class="navbar navbar-expand-lg navbar-light bg-transparent mb-0">
-    <div class="collapse navbar-collapse text-center mb-0" id="navigation">
-        <ul class="navbar navbar-nav mx-auto mb-0">
-            <li class="nav-item">
-                <a class="nav-link" href="https://www.eventbrite.com/e/innersource-summit-2024-tickets-943448669367">Register</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#keynote-speakers">Speakers</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#sponsorship">Sponsor</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="mailto:summit_team@innersourcecommons.org">Contact Us</a>
-            </li>
-        </ul>
-    </div>
-</nav>
-
-<img src="/images/events/summit-2024.png"></img>
-
 ### Registrations are Now Open
 #### 20th & 21st November 2024 - online
-
 **Join us at the world's leading gathering of InnerSource practitioners.**
 
 **[Get Your Ticket Now!](https://www.eventbrite.com/e/innersource-summit-2024-tickets-943448669367)**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: Innersourcecommons
 services:
   server:
     # The version here must be kept in sync with the one used at .github/workflows/main.yml
-    image: hugomods/hugo:base-0.133.1
+    image: hugomods/hugo:base-0.145.0
     command: server -D
     volumes:
       - ./:/src

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -42,7 +42,7 @@
           </div>
           <div class="card-body p-0 d-flex flex-column">
             <h3><a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="post-title">{{ .Title }}</a></h3>
-            <p class="card-text event-card-text">{{ .Summary }}</p>
+            <p class="">{{ .Summary }}</p>
             <div class="d-flex mt-auto flex-md-row flex-sm-column">
               <a href="{{ default .Permalink .Params.redirect }}"{{ with .Params.target }} target="{{ . }}"{{ end }} class="btn btn-primary btn-sm mr-md-1">Open Event</a>
               {{ if .Params.youtubeLink }}


### PR DESCRIPTION
Fixes the 2024 summit breaking the flow of the events. Also removes paragraph class that was causing a bunch of empty space on top of the event descriptions. Also bumps up the version in the docker compose yml to match the production version.