### PR TITLE
chore: move 2024 summit to past summits and remove it from menus

### DIFF
--- a/config/_default/menus.de.yaml
+++ b/config/_default/menus.de.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.es.yaml
+++ b/config/_default/menus.es.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.it.yaml
+++ b/config/_default/menus.it.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.ja.yaml
+++ b/config/_default/menus.ja.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.pt-br.yaml
+++ b/config/_default/menus.pt-br.yaml
@@ -71,12 +71,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -158,9 +158,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.ru.yaml
+++ b/config/_default/menus.ru.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/config/_default/menus.zh.yaml
+++ b/config/_default/menus.zh.yaml
@@ -73,12 +73,12 @@ main:
     URL: https://gatherings.innersourcecommons.org/
     parent: community
     weight: 6
-  - name: InnerSource Summit 2024
-    URL: events/isc-2024
-    parent: community
-    weight: 7
+  # - name: InnerSource Summit 2024
+  #   URL: events/isc-2024
+  #   parent: community
+  #   weight: 7
   - name: Past Summits
-    URL: https://innersourcecommons.org/events/past-summits/
+    URL: events/past-summits
     parent: community
     weight: 8
   - name: InnerSourcerers Map
@@ -160,9 +160,9 @@ footer_middle:
     URL: events/community-calls
     weight: 1
     post: bold
-  - name: Summit 2024
-    URL: events/isc-2024
-    weight: 2
+  # - name: Summit 2024
+  #   URL: events/isc-2024
+  #   weight: 2
   - name: Local Gatherings
     URL: https://gatherings.innersourcecommons.org/
     weight: 3

--- a/content/en/events/past-summits.md
+++ b/content/en/events/past-summits.md
@@ -7,6 +7,22 @@ type: page
         <div class="card border-0 h-100">
             <div class="h-md-45">
                 <a class="primary-link" href="https://innersourcecommons.org/events/isc-2023/">
+                    <img src="/images/events/summit-2024.png" alt="InnerSource Summit 2024" class="card-img rounded-lg">
+                </a>
+                </div>
+                <div class="card-body p-0 d-flex flex-column">
+                <h3><a href="https://innersourcecommons.org/events/isc-2023/" class="post-title">InnerSource Summit 2024</a></h3>
+                <p class="card-text event-card-text">Registrations are Now Open 20th & 21st November 2024 - online. Join us at the world’s leading gathering of InnerSource practitioners.</p>
+                <div class="d-flex mt-auto flex-md-row flex-sm-column">
+                    <a href="https://innersourcecommons.org/events/isc-2023/" class="btn btn-primary primary-link btn-sm mr-md-1">Open Event</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4 col-sm-6 mb-5 event-card">
+        <div class="card border-0 h-100">
+            <div class="h-md-45">
+                <a class="primary-link" href="https://innersourcecommons.org/events/isc-2023/">
                     <img src="/images/events/Summit2023.jpg" alt="InnerSource Summit 2023" class="card-img rounded-lg">
                 </a>
                 </div>


### PR DESCRIPTION
Closes https://github.com/InnerSourceCommons/InnerSourceMarketing/issues/402#event-17248391655