### PR TITLE
Ensure the Nearest Upcoming Event Is Displayed First

### DIFF
--- a/data/featured_articles.yaml
+++ b/data/featured_articles.yaml
@@ -25,13 +25,9 @@ learning:
     visible: true
 
 community:
-  - title: "InnerSource Gathering Berlin 2025 is open for registration!"
-    image: "/images/photos/berlin-2025.png"
-    link: https://gatherings.innersourcecommons.org/berlin-2025/
-    visible: true
-  - title: Call for Hosts for InnerSource Summit 2025
-    image: "/images/photos/call-for-hosts.png"
-    link: https://docs.google.com/forms/d/e/1FAIpQLSdjeQFYDVT_0pVwMJTHTmArMPLtq7oHwBO8CgQzd_aV0UxRKA/viewform
+  - title: "InnerSource Gathering London 2025 is open for registration!"
+    image: "https://gatherings.innersourcecommons.org/images/gathering/london-2025.png"
+    link: https://gatherings.innersourcecommons.org/london-2025/
     visible: true
 
 blog:

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -122,19 +122,21 @@
                 </ul>
                 <div class="featured-articles">
                   {{ $pages := where site.Pages "Type" "in" "redirects" }}
-                  {{ $pages = where $pages "Section" "events" }}
-                  {{ range first 1 ($pages.ByDate.Reverse) }}
-                  <div class="article-card">
-                    <a href="{{ .Params.redirect }}" class="article-link" target="_blank">
-                      <div class="article-image">
-                        <img src="{{ .Params.image }}" alt="{{ .Title }}">
-                      </div>
-                      <div class="article-content">
-                        <h4>{{ .Title }} will be held on {{ .Date.Format "January 2, 2006" }}</h4>
-                      </div>
-                    </a>
-                  </div>
-                  {{ end }}
+                                    {{ $pages = where $pages "Section" "events" }}
+                                    {{ $now := now }}
+                                    {{ $futureEvents := where $pages "Date" "ge" $now }}
+                                    {{ range first 1 ($futureEvents.ByDate) }}
+                                    <div class="article-card">
+                                      <a href="{{ .Params.redirect }}" class="article-link" target="_blank">
+                                        <div class="article-image">
+                                          <img src="{{ .Params.image }}" alt="{{ .Title }}">
+                                        </div>
+                                        <div class="article-content">
+                                          <h4>{{ .Title }} will be held on {{ .Date.Format "January 2, 2006" }}</h4>
+                                        </div>
+                                      </a>
+                                    </div>
+                                    {{ end }}
                   {{ range where site.Data.featured_articles.community "visible" true }}
                   <div class="article-card">
                     <a href="{{ .link }}" class="article-link">

--- a/layouts/shortcodes/upcoming-event-card.html
+++ b/layouts/shortcodes/upcoming-event-card.html
@@ -2,11 +2,19 @@
 
 {{ $pages := where site.Pages "Type" "in" "redirects" }}
 {{ $pages = where $pages "Section" "events" }}
-{{ range first 1 ($pages.ByDate.Reverse) }}
-  <div style="position: relative; border: none; box-shadow: none;">
-    <div style="position: absolute; top: 10px; left: 10px; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; color: white; background: rgba(0, 0, 0, 0.5); padding: 4px 8px; border-radius: 2px; z-index: 1;">Upcoming Event</div>
-    <a href="{{ .Params.redirect }}" class="event-link" target="_blank" style="text-decoration: none; color: inherit; display: block; border: none;">
-      <img src="{{ .Params.image }}" alt="{{ .Title }}" style="width: 100%; display: block; border: none; margin: 0; border-radius: 6px;">
-    </a>
-  </div>
+{{ $now := now }}
+{{ $futureEvents := where $pages "Date" "ge" $now }}
+{{ $upcomingEvent := first 1 ($futureEvents.ByDate) }}
+
+{{ if $upcomingEvent }}
+  {{ range $upcomingEvent }}
+    <div style="position: relative; border: none; box-shadow: none;">
+      <div style="position: absolute; top: 10px; left: 10px; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; color: white; background: rgba(0, 0, 0, 0.5); padding: 4px 8px; border-radius: 2px; z-index: 1;">Upcoming Event</div>
+      <a href="{{ .Params.redirect }}" class="event-link" target="_blank" style="text-decoration: none; color: inherit; display: block; border: none;">
+        <img src="{{ .Params.image }}" alt="{{ .Title }}" style="width: 100%; display: block; border: none; margin: 0; border-radius: 6px;">
+      </a>
+    </div>
+  {{ end }}
+{{ else }}
+  <!-- If no upcoming events, show a placeholder or nothing -->
 {{ end }}


### PR DESCRIPTION
#### **Overview**

Previously, the logic for displaying upcoming events could result in the most distant future event being shown. This PR fixes that behavior by ensuring the *nearest* upcoming event is always displayed.

#### **Changes**

* Modified the logic to use `$futureEvents.ByDate` to sort upcoming events in ascending order by date
* Now displays the first event in the list (i.e., the soonest upcoming event)

**Affected files:**

* `layouts/shortcodes/upcoming-event-card.html`
* `layouts/partials/header.html`

#### **How to Test**

1. Create multiple upcoming events in the content directory (e.g., an existing event on `2025-05-06` and others with later dates)
2. Serve the website locally
3. Verify that the event with the nearest future date is the one displayed

