### PR TITLE
chore: disable the pr preview step

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,8 +1,8 @@
 name: PR Preview
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   build-preview:


### PR DESCRIPTION
Commenting out the PR preview step that copilot introduced some time ago as it doesn't work.