### PR TITLE
Menu Update

### DIFF
--- a/config/_default/menus.de.yaml
+++ b/config/_default/menus.de.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -57,23 +57,6 @@ main:
     parent: about
     weight: 7
 
-  # # Summit 2025
-  - name: Summit 2025
-    weight: 3
-    identifier: summit-2025
-  - name: When and Where
-    URL: /events/isc-2025/
-    parent: summit-2025
-    weight: 1
-  - name: Call for Presenters
-    URL: /events/isc-2025/
-    parent: summit-2025
-    weight: 2
-  - name: Why Sponsor
-    URL: /events/isc-2025/
-    parent: summit-2025
-    weight: 3
-
   # Community
   - name: Community
     weight: 3
@@ -200,12 +183,26 @@ main:
     URL: /events/isc-2025/
     parent: events
     weight: 6
+    identifier: summit-2025
     params:
       column: types
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: events
+    weight: 7
+    params:
+      column: types
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: events
+    weight: 8
+    params:
+      column: types
+
   - name: InnerSource Past Summits
     URL: /events/past-summits/
     parent: events
-    weight: 7
+    weight: 9
     params:
       column: types
 

--- a/config/_default/menus.es.yaml
+++ b/config/_default/menus.es.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.it.yaml
+++ b/config/_default/menus.it.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.ja.yaml
+++ b/config/_default/menus.ja.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.pt-br.yaml
+++ b/config/_default/menus.pt-br.yaml
@@ -75,10 +75,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.ru.yaml
+++ b/config/_default/menus.ru.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community

--- a/config/_default/menus.zh.yaml
+++ b/config/_default/menus.zh.yaml
@@ -77,10 +77,19 @@ main:
     URL: events/isc-2025
     parent: community
     weight: 7
+    identifier: summit-2025
+  - name: Call for Presenters
+    URL: https://docs.google.com/forms/d/e/1FAIpQLSfWKkRDWIYN8eTOMlxONZp23-_i9nnAfqSJm26QCdzS5NtO9w/viewform
+    parent: community
+    weight: 8
+  - name: Why Sponsor the InnerSource Summit 2025?
+    URL: /events/isc-2025/#why-sponsor?
+    parent: community
+    weight: 9
   - name: Past Summits
     URL: events/past-summits
     parent: community
-    weight: 8
+    weight: 10
   - name: InnerSourcerers Map
     URL: about/map
     parent: community


### PR DESCRIPTION
I updated the menu based on the comments left on the last PR merged: https://github.com/InnerSourceCommons/innersourcecommons.org/pull/1048

The Summit links are now under events as follows: 
<img width="1233" alt="image" src="https://github.com/user-attachments/assets/87442c40-2e76-4f15-8846-6f1b077011e8" />
