### PR TITLE
fix: make spacing more even in menu

### DIFF
--- a/static/css/custom-menu.css
+++ b/static/css/custom-menu.css
@@ -96,6 +96,7 @@
 .menu-item-has-children {
   position: static;
   padding: 0;
+  width: 100%;
 }
 
 .menu-item-has-children > a {
@@ -106,6 +107,7 @@
   display: block;
   position: relative;
   font-size: 14px;
+  text-align: center;
 }
 
 .menu-item-has-children > a::after {

--- a/static/css/custom-menu.css
+++ b/static/css/custom-menu.css
@@ -215,7 +215,7 @@
   display: flex;
   align-items: center;
   gap: 15px;
-  margin-left: auto;
+  margin-left: 1rem;
 }
 
 .header-cta .btn {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/aeaa0182-f234-4c4c-b7cf-dac9ed9d5d7a)
After: 
![image](https://github.com/user-attachments/assets/dda21996-bda3-41e6-bb01-cdeb64a52f5d)


Closes https://github.com/InnerSourceCommons/InnerSourceMarketing/issues/420