### PR TITLE
fix: Remove hardcoded calendar timezone

### DIFF
--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -151,7 +151,7 @@ main:
     params:
       column: general
   - name: Events Calendar
-    URL: https://calendar.google.com/calendar/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4%40group.calendar.google.com&ctz=Europe%2FDublin
+    URL: https://calendar.google.com/calendar/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4%40group.calendar.google.com
     parent: events
     weight: 2
     params:


### PR DESCRIPTION
Removed the hardcoded timezone on google calendar (`ctz` url parameter).

As per my tests, without the `ctz` paramenter, the calendar is shown at my own timezone, so I assume there is some automatic detection feature in it.

Was added with a15e7704ccfa662e575603c2290397b3921cb155.

Related comment:
- https://github.com/InnerSourceCommons/innersourcecommons.org/pull/1010#issuecomment-3051576693