### PR TITLE
fix: redirect to English if translation doesnt exist

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,6 +1,10 @@
 baseURL: 'https://innersourcecommons.org/'
 defaultContentLanguage: 'en'
 defaultContentLanguageInSubdir: false
+params:
+  # Redirect to default language if translation is missing
+  redirectMissingTranslations: true
+
 title: InnerSource Commons
 
 pluralizeListTitles: false

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,4 +9,29 @@
 	{{- partial "footer.html" . -}}
 </body>
 
+{{ if not .Content }}
+ {{ if .Site.Params.redirectMissingTranslations }}
+	<script>
+		const path = window.location.pathname;
+		const pathParts = path.split('/');
+		const currentLang = pathParts[1];
+		
+		// If not English, try English version
+		if (currentLang !== 'en' && currentLang.length === 2) {
+			const englishPath = path.replace(`/${currentLang}/`, '/en/');
+			
+			// Check if English version exists (you'd need to implement this check)
+			fetch(englishPath)
+			.then(response => {
+				if (response.ok) {
+				window.location.href = englishPath;
+				}
+			})
+			.catch(() => {
+				// Show 404 page
+			});
+		}
+	</script>
+  {{ end }}
+{{ end }}
 </html>


### PR DESCRIPTION
Added a config parameter so we can turn off the behavior if needed. 
Closes https://github.com/InnerSourceCommons/InnerSourceMarketing/issues/430#event-19273280694