### PR TITLE
Fix: correct homepage logo link in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,9 @@
         {{ end }}
       </div>
       <div class="col-md-3 col-sm-6 mb-5">
-        <a class="d-block mb-3" href='{{ site.BaseURL }}{{ if eq .Site.Language.Lang "en" }}{{ site.BaseURL }}{{ else }}{{ site.BaseURL }}{{ .Site.Language.Lang }}{{end}}'><img width="{{site.Params.logo_width}}"   class="img-fluid" src="{{ site.Params.logo | absURL }}" alt="{{ site.Title }}"></a>
+        <a class="d-block mb-3" href='{{ if eq .Site.Language.Lang "en" }}/{{ else }}/{{ .Site.Language.Lang }}/{{ end }}'>
+          <img width="{{site.Params.logo_width}}" class="img-fluid" src="{{ site.Params.logo | absURL }}" alt="{{ site.Title }}">
+        </a>
         <p class="mb-4">{{ T "footer_content" }}</p>
         
         


### PR DESCRIPTION
## Description
This PR fixes a broken link in the site footer. Previously, clicking the logo at the bottom right of the homepage resulted in a 404 error due to incorrect URL construction. The logic now ensures:

For English (en), the logo links to the root path /
For other languages, the logo links to the language root (e.g., /fr/)
This guarantees the logo always points to a valid homepage URL for the current language.

## Website Preview
<img width="1138" height="809" alt="image" src="https://github.com/user-attachments/assets/a82689c2-4a56-4127-a59b-98e8fa1d42b9" />

## Checklist
- [x] I have tested these changes locally
- [x] I have updated documentation if necessary
- [x] I have verified the preview looks as expected (when the preview comment appears)