### PR TITLE
feat: adds the link to the a-i page to the general events menu

### DIFF
--- a/config/_default/menus.de.yaml
+++ b/config/_default/menus.de.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.en.yaml
+++ b/config/_default/menus.en.yaml
@@ -202,6 +202,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.es.yaml
+++ b/config/_default/menus.es.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.it.yaml
+++ b/config/_default/menus.it.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.ja.yaml
+++ b/config/_default/menus.ja.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.pt-br.yaml
+++ b/config/_default/menus.pt-br.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.ru.yaml
+++ b/config/_default/menus.ru.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates

--- a/config/_default/menus.zh.yaml
+++ b/config/_default/menus.zh.yaml
@@ -198,6 +198,12 @@ main:
     weight: 9
     params:
       isSecondary: true
+  - name: Summit Inclusion & Accessibility
+    URL: /events/isc-summit-2025-di/
+    parent: events
+    weight: 10
+    params:
+      isSecondary: true
  
   # News & Updatess
   - name: News & Updates


### PR DESCRIPTION
Adds the link to the accessibility and inclusion page in the genera events menu: 
<img width="311" height="224" alt="image" src="https://github.com/user-attachments/assets/c7b7eba0-8964-4ee7-807c-49f0ebbe550a" />
