### PR TITLE
fix: adjust description height

### DIFF
--- a/static/plugins/youmax/youmax.css
+++ b/static/plugins/youmax/youmax.css
@@ -95,10 +95,10 @@
 	color: #0aa8a7;
 	display: inline-block;
 	padding: 15px 20px;
-  font-weight: bold;
-  font-size: 15px;
+  	font-weight: bold;
+  	font-size: 15px;
 	max-width: 350px;
-  height: 60px;
+  	height: 80px;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
Description was getting cut off when the description spanned more than 3 lines. This allows 3 line descriptions