### PR TITLE
hotfix: do not fail if links are not found

### DIFF
--- a/.github/workflows/link-checker-prs.yml
+++ b/.github/workflows/link-checker-prs.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d $MARKDOWN_FILES
           fail: true
+          failIfEmpty: false
           jobSummary: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Markdown files cannot always be scanned correctly be linkchecker causing it to fail