### PR TITLE
announcements: promote UN case study to featured hero slot

### DIFF
--- a/content/en/about/announcements/2025-05-new-board-and-officers.md
+++ b/content/en/about/announcements/2025-05-new-board-and-officers.md
@@ -3,7 +3,6 @@ layout: page
 title: 'InnerSource Commons welcomes our new Board and Officers'
 image: "/images/about/announcements/2025-05-new-board-and-officers.png"
 date: 2025-05-22
-featured: true
 type: "announcements"
 ---
 May 22, 2025

--- a/content/en/about/announcements/2026-06-un-case-study.md
+++ b/content/en/about/announcements/2026-06-un-case-study.md
@@ -1,8 +1,9 @@
 ---
 layout: page
 title: 'The United Nations Put InnerSource to Work, and Shipped'
-image: "/images/about/announcements/2026-06-un-case-study.png"
+image: "/images/logos/united-nations.png"
 date: 2026-06-29
+featured: true
 type: "announcements"
 ---
 


### PR DESCRIPTION
## Summary

- Moves `featured: true` from the 2025 board elections post to the UN case study, so the UN story appears in the hero slot at the top of `/about/announcements/`
- Swaps the UN case study announcement image from the detailed infographic to the clean UN logo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
