### PR TITLE
isc-2026: make clear the summit is a fully virtual event

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -12,7 +12,7 @@ bigHeading: true
 <!-- ***Talk to us now on info@innersourcecommons.org to find out how you can be part of this year's summit or fill out our [Expression of Interest form](https://docs.google.com/forms/d/e/1FAIpQLSfPV4TURwC9czP5Sn5AfXY4E7QGRYHdjZgSKExrL7b5pjGtFg/viewform) -->
 <br />
 
-**🌐 This is a fully virtual event - join online from anywhere in the world.**
+<p class="text-center"><strong>This is a fully virtual event - join online from anywhere in the world.</strong></p>
 <br />
 <br />
 

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -12,7 +12,11 @@ bigHeading: true
 <!-- ***Talk to us now on info@innersourcecommons.org to find out how you can be part of this year's summit or fill out our [Expression of Interest form](https://docs.google.com/forms/d/e/1FAIpQLSfPV4TURwC9czP5Sn5AfXY4E7QGRYHdjZgSKExrL7b5pjGtFg/viewform) -->
 <br />
 
-On Thursday, November 12th, InnerSource Summit 2026 will unite the global InnerSource community for a 22-hour around-the-world event spanning every timezone!  We will be featuring the industry’s top speakers, inspiring stories, and cutting-edge ideas shaping the future of collaborative software development. 
+**🌐 This is a free, fully virtual event - join online from anywhere in the world.**
+<br />
+<br />
+
+On Thursday, November 12th, InnerSource Summit 2026 will unite the global InnerSource community online for a 22-hour around-the-world event spanning every timezone!  We will be featuring the industry’s top speakers, inspiring stories, and cutting-edge ideas shaping the future of collaborative software development. 
 <br />
 <br />
 Discover the Power of InnerSource!

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -12,7 +12,7 @@ bigHeading: true
 <!-- ***Talk to us now on info@innersourcecommons.org to find out how you can be part of this year's summit or fill out our [Expression of Interest form](https://docs.google.com/forms/d/e/1FAIpQLSfPV4TURwC9czP5Sn5AfXY4E7QGRYHdjZgSKExrL7b5pjGtFg/viewform) -->
 <br />
 
-**🌐 This is a free, fully virtual event - join online from anywhere in the world.**
+**🌐 This is a fully virtual event - join online from anywhere in the world.**
 <br />
 <br />
 


### PR DESCRIPTION
## Summary
- Adds a clear "fully virtual event" callout, centered and bold, near the top of the InnerSource Summit 2026 page
- A prospective speaker declining our invite pointed out the page doesn't say whether the event is online or in-person

## Test plan
- [x] Previewed the `/events/isc-2026` page locally (`hugo server`) and confirmed the callout renders correctly
