### PR TITLE
Fix broken "Volunteer at Summit" link on quick-start guide

### DIFF
--- a/content/en/community/quick-start-guide.md
+++ b/content/en/community/quick-start-guide.md
@@ -145,7 +145,7 @@ You have time and skills and want to make a difference. Jump in:
 - Learn about the [InnerSource Commons Foundation](/about/)
 - Join our [Slack](/slack)
 - Attend (or better yet, offer to speak at or facilitate!) a [Community Call](/events/community-calls/)
-- Offer to [Volunteer at Summit (November 2025)](https://innersourcecommons.slack.com/archives/C08FEDXH4GP)
+- Offer to [Volunteer at Summit](https://docs.google.com/forms/d/e/1FAIpQLScJl68JOJla9luOd4lRIvLCRMCHtKQY_ReW_KQC4HO_pdXd5Q/viewform)
 - Learn about the [Groups](/community/) inside the InnerSource Commons
 - Begin to connect with areas that align most with your interests:
 


### PR DESCRIPTION
## What & why

The **"Volunteer at Summit"** bullet on the [quick-start / contribution-opportunities page](https://innersourcecommons.org/community/quick-start-guide/) was a broken call-to-action. It linked to `#summit2025planning` (`C08FEDXH4GP`), which is:

1. **Private** — a newcomer clicking it from this public page lands on a channel they can't access.
2. **For a past summit** — the "November 2025" summit is over.

## The fix

Point the link at the **official Summit Volunteer Form** — the same Google Form linked from the current [Summit event page](https://innersourcecommons.org/events/isc-2026/) — so the CTA drops the visitor straight into the real sign-up. Also removed the hard-coded "November 2025" so the callout stays correct for future summits.

```diff
- - Offer to [Volunteer at Summit (November 2025)](https://innersourcecommons.slack.com/archives/C08FEDXH4GP)
+ - Offer to [Volunteer at Summit](https://docs.google.com/forms/d/e/1FAIpQLScJl68JOJla9luOd4lRIvLCRMCHtKQY_ReW_KQC4HO_pdXd5Q/viewform)
```

Addresses the "broken link on the Volunteer at Summit page" item from the ISPO/ISC Working Group meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
