### PR TITLE
un-case-study: remove Google/Oregon State research-project claim

### DIFF
--- a/content/en/about/announcements/2026-06-un-case-study.md
+++ b/content/en/about/announcements/2026-06-un-case-study.md
@@ -11,7 +11,7 @@ type: "announcements"
 
 A new case study from UN Open Source Week documents **Reboot UN-tapped**, an eight-week accelerator run by the UN Secretariat on InnerSource principles. 100 staff from more than 40 UN entities, across 25-plus locations, built solutions to real peacekeeping challenges using internal talent rather than outside vendors.
 
-Fifteen prototypes came out of it. Two are now being implemented in missions in Cyprus and South Sudan, and a third became a research project with Google and Oregon State University.
+Fifteen prototypes came out of it. Two are now being implemented in missions in Cyprus and South Sudan.
 
 It is one of the clearest examples yet of InnerSource at the scale of the world's hardest problems. Read the full case study here: [United Nations InnerSource Case Study](/case-studies/united-nations/).
 


### PR DESCRIPTION
Removes the sentence clause **"and a third became a research project with Google and Oregon State University."** from the [UN case study announcement](https://innersourcecommons.org/about/announcements/2026-06-un-case-study/), per an urgent request from Addie.

The announcement now reads:

> Fifteen prototypes came out of it. Two are now being implemented in missions in Cyprus and South Sudan.

Addie flagged the `/pt-br/` path, but there is no Portuguese translation of this announcement — Hugo serves the English source via its language fallback, so removing the clause from the single English content file fixes every localized path (`/`, `/pt-br/`, `/fr/`, `/ja/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
