### PR TITLE
Fix bullet-list text rendering smaller than paragraph text

### DIFF
--- a/assets/scss/_custom.scss
+++ b/assets/scss/_custom.scss
@@ -219,6 +219,12 @@ ol.breadcrumb {
     width: 100%;
 }
 
+.content {
+    ul, ol {
+        font-size: 16px;
+    }
+}
+
 .page-header-with-logo {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- Fixes a site-wide bug where bullet/numbered list text in page body content rendered at 12px instead of the 16px used by surrounding paragraph text.
- Root cause: `body` sets a 12px baseline `font-size`, which most text elements (e.g. `p`, `.paragraph`) explicitly override back to 16px, but `ul`/`ol` never got that override, so they inherited the tiny body size.
- Scoped the fix to `.content` (the wrapper used for markdown-rendered body copy) rather than a blanket `ul, li` rule, so nav menus, footers, and card lists that may intentionally use smaller list text are unaffected.

## Verification
Confirmed on http://localhost/case-studies/united-nations/ via computed styles and screenshots — before the fix, sibling `<p>`/`<li>` in `.content` measured 16px/12px; after, both measure 16px.

Spot-checked two additional content pages (`/community/quick-start-guide/`, `/case-studies/microsoft/`) — same 16px/16px result, nothing else visibly regressed.

**Before:**
`<li>` renders at 12px, noticeably smaller than the paragraph text above it.

**After:**
`<li>` renders at 16px, matching the paragraph text.

## Test plan
- [x] `hugo server -D` locally, confirmed bullet list on the UN case study page now matches paragraph text size
- [x] Spot-checked 2 other content pages with bullet lists — fix applies, no regressions
- [ ] Reviewer: spot-check nav/footer/card lists elsewhere on the site remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
