### PR TITLE
fix: restore UN logo in About-page carousel and announcements hero

### DIFF
--- a/content/en/about/announcements/2026-06-un-case-study.md
+++ b/content/en/about/announcements/2026-06-un-case-study.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: 'The United Nations Put InnerSource to Work, and Shipped'
-image: "/images/about/announcements/2026-06-un-case-study.png"
+image: "/images/logos/united-nations.png"
 logo: "/images/logos/united-nations.png"
 date: 2026-06-29
 featured: true


### PR DESCRIPTION
## Summary
- The About-page hero carousel was showing the UN case study's "Reboot Untapped, by the numbers" stats infographic instead of the compact UN emblem logo, because it doesn't fit the small carousel slot.
- PR #1204 fixed the oversized-logo problem on the single announcement page by introducing a separate `logo` front-matter field and a compact header template, but left `image` pointing at the wide infographic.
- `image` is still read by two other places that need something compact: the About-page carousel (`layouts/shortcodes/announcements.html`) and the announcements list-page featured hero (`layouts/announcements/list.html`).
- Sets `image` back to the UN logo (matching `logo`), restoring the pre-#1204 carousel/list-page appearance while leaving #1204's compact single-page header untouched (it reads `logo`, not `image`).

## Test plan
- [x] Ran `hugo server -D` and confirmed via rendered HTML that `/about/` carousel now renders `/images/logos/united-nations.png` for the UN slide.
- [x] Confirmed `/about/announcements/` featured hero (col-md-6, `w-100`) renders the logo, not the infographic.
- [x] Confirmed `/about/announcements/2026-06-un-case-study/` single page is unaffected — still uses the compact `logo` header, unchanged by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
