### PR TITLE
Restore Yuki Hattori to the outgoing-board thanks list

### DIFF
--- a/content/en/about/announcements/2026-07-new-board.md
+++ b/content/en/about/announcements/2026-07-new-board.md
@@ -44,7 +44,7 @@ We are super thrilled to have such a great force and diverse experiences joining
 
 ### Thank You to Our Outgoing Board
 
-We also extend our deepest appreciation to our outgoing Board members - Clare Dillon, Matt Cobby, Daniel Izquierdo Cortázar, Jerry Tan, Cristina Coffey, and Danese Cooper. The Foundation runs better today because of the insights, commitment, and time they gave it.
+We also extend our deepest appreciation to our outgoing Board members - Clare Dillon, Matt Cobby, Daniel Izquierdo Cortázar, Jerry Tan, Cristina Coffey, Yuki Hattori, and Danese Cooper. The Foundation runs better today because of the insights, commitment, and time they gave it.
 
 ### How the Board Is Chosen
 


### PR DESCRIPTION
Yuki was elected to last year's board and isn't on this year's, so he belongs in the normal outgoing-members thank-you alongside the others. A prior edit on #1211 removed him on the mistaken assumption that his mid-term resignation meant he shouldn't be named at all.