### PR TITLE
Fix spelling of Reboot Untapped in UN case study announcement

### DIFF
--- a/content/en/about/announcements/2026-06-un-case-study.md
+++ b/content/en/about/announcements/2026-06-un-case-study.md
@@ -10,7 +10,7 @@ type: "announcements"
 
 ### A New Case Study from UN Open Source Week
 
-A new case study from UN Open Source Week documents **Reboot UN-tapped**, an eight-week accelerator run by the UN Secretariat on InnerSource principles. 100 staff from more than 40 UN entities, across 25-plus locations, built solutions to real peacekeeping challenges using internal talent rather than outside vendors.
+A new case study from UN Open Source Week documents **Reboot Untapped**, an eight-week accelerator run by the UN Secretariat on InnerSource principles. 100 staff from more than 40 UN entities, across 25-plus locations, built solutions to real peacekeeping challenges using internal talent rather than outside vendors.
 
 Fifteen prototypes came out of it. Two are now being implemented in missions in Cyprus and South Sudan.
 


### PR DESCRIPTION
## Summary
- The announcement page's body text read "Reboot UN-tapped" while the case study page and its graphics already use the correct "Reboot Untapped".

## Test plan
- [x] Confirmed no other occurrences of "UN-tapped" remain in `content/`
