### PR TITLE
rebrand ISPO Working Group to InnerSource Working Group

### DIFF
--- a/content/en/about/board/_index.md
+++ b/content/en/about/board/_index.md
@@ -46,7 +46,7 @@ He holds an MA in International Studies from the University of Birmingham.
 {{< /board-member >}}
 
 {{< board-member name="Jeff Bailey" title="Secretary" image="/images/about/Jeff_Bailey.png" >}}
-Jeff Bailey is a Principal Software Engineer at Nike. He has been an active member of the InnerSource Commons community since 2021 and became a formal member in 2024. Jeff is a Trusted Committer and a member of the <a href="https://github.com/InnerSourceCommons/ispo-working-group/">InnerSource Program Office Working Group (ISPO WG)</a>, where he contributes to shaping best practices and enabling organizational scale. He is passionate about driving InnerSource and Open Source communities of practice to power global platform engineering efforts, and has played a key role in scaling these efforts at Nike. Jeff focuses on fostering collaboration, reducing organizational friction, and creating sustainable software systems that enable teams to share, contribute, and innovate more effectively. 
+Jeff Bailey is a Principal Software Engineer at Nike. He has been an active member of the InnerSource Commons community since 2021 and became a formal member in 2024. Jeff is a Trusted Committer and a member of the <a href="https://github.com/InnerSourceCommons/innersource-working-group/">InnerSource Working Group</a>, where he contributes to shaping best practices and enabling organizational scale. He is passionate about driving InnerSource and Open Source communities of practice to power global platform engineering efforts, and has played a key role in scaling these efforts at Nike. Jeff focuses on fostering collaboration, reducing organizational friction, and creating sustainable software systems that enable teams to share, contribute, and innovate more effectively. 
 {{< /board-member >}}
 
 {{< board-member name="Aaron Williamson" title="Assistant Secretary" image="/images/about/Aaron_Williamson.jpg" style="bg-light" >}}
@@ -67,7 +67,7 @@ Georg Grütter is an InnerSource evangelist and Developer Advocate at Robert Bos
 Guilherme Dellagustin is InnerSource Officer at SAP, where he drives InnerSource adoption through presentations, event organization, mentoring, and leading by example.
 He has been with SAP since 2010, working as a developer and senior developer on payroll solutions across Latin America and Europe before taking on the InnerSource Officer role, and has been promoting InnerSource at SAP and across the industry since 2019.
 In his own words, promoting InnerSource is how he spreads the culture and values of open source.
-Guilherme organized the European leg of the InnerSource Summit 2025, is a consistent presence in the <a href="https://github.com/InnerSourceCommons/ispo-working-group/">InnerSource Program Office Working Group (ISPO WG)</a> and the LATAM community, and has given several presentations on InnerSource practice.
+Guilherme organized the European leg of the InnerSource Summit 2025, is a consistent presence in the <a href="https://github.com/InnerSourceCommons/innersource-working-group/">InnerSource Working Group (ISWG)</a> and the LATAM community, and has given several presentations on InnerSource practice.
 He holds a degree in physics from the Federal University of Rio Grande do Sul.
 {{< /board-member >}}
 

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -106,14 +106,14 @@ title: "Community"
   </div>
 </section>
 
-<section class="section bg-light" id="ispo">
+<section class="section bg-light" id="iswg">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-6 order-2 order-md-1">
-        <p class="section-title h2">ISPO Working Group</p>
-        <p>The ISPO Working Group supports InnerSource Program Offices (ISPOs) with materials needed to establish themselves, teach and scale InnerSource in their respective company. The group holds regular meetings, but most work is done asynchronously on <a href="https://github.com/InnerSourceCommons/ispo-working-group" target="_blank">GitHub</a>.
+        <p class="section-title h2">InnerSource Working Group</p>
+        <p>The InnerSource Working Group supports InnerSource practitioners with materials needed to establish themselves, teach and scale InnerSource in their respective company. The group holds regular meetings, but most work is done asynchronously on <a href="https://github.com/InnerSourceCommons/innersource-working-group" target="_blank">GitHub</a>.
         </p>
-        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/> ispo-working-group</a>
+        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/>innersource-working-group</a>
       </div>
       <div class="col-md-5 order-1 order-md-2 mb-4 mb-md-0">
         <img src="/images/community/cuate.png" class="img-fluid">

--- a/content/en/community/quick-start-guide.md
+++ b/content/en/community/quick-start-guide.md
@@ -59,14 +59,14 @@ You’re interested in potentially engaging, but don’t have much time. Start s
 - Begin to connect with areas that align most with your interests:
 
 
-### ISPO Working Group
+### InnerSource Working Group
 
-**Description:** This working group is for those who are managing InnerSource projects, working in established ISPOs, or looking to start an ISPO in their company. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
+**Description:** This working group is for InnerSource practitioners. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
 
-- Join [Slack](/slack) and the ISPO working group channel
-- Watch the [introductory video](https://www.youtube.com/watch?v=r8Ce7GlwBeA)
-- Read through the group’s [Website](https://innersourcecommons.github.io/ispo-working-group/)
-- Attend 1 [ISPO Working Group meeting](https://calendar.google.com/calendar/u/0/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4@group.calendar.google.com)
+- Join [Slack](/slack) and the #innersource-working-group channel
+- Watch the [introductory video](https://github.com/InnerSourceCommons/innersource-working-group/tree/main#recording)
+- Read through the group's [Website](https://innersourcecommons.github.io/innersource-working-group/)
+- Attend 1 [InnerSource Working Group meeting](https://calendar.google.com/calendar/u/0/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4@group.calendar.google.com)
 
 ### Patterns Working Group
 **Description:** This working group is for those who are managing InnerSource projects and looking to solve or share solutions to specific obstacles that are often encountered. This group works asynchronously in GitHub and [Slack](/slack).
@@ -100,14 +100,14 @@ You are interested in building loose connections with the community and have a l
 - Begin to connect with areas that align most with your interests:
 
 
-## ISPO Working Group
+## InnerSource Working Group
 
-**Description:** This working group is for those who are managing InnerSource projects, working in established ISPOs, or looking to start an ISPO in their company. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
+**Description:** This working group is for all InnerSource practitioners. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
 
-- Join [Slack](/slack) and the ISPO working group channel
-- Watch the [introductory video](https://www.youtube.com/watch?v=r8Ce7GlwBeA)
-- Read through the group’s [Website](https://innersourcecommons.github.io/ispo-working-group/)
-- Add the [ISPO Working Group meeting](https://calendar.google.com/calendar/u/0/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4@group.calendar.google.com) to your calendar and plan to attend regularly
+- Join [Slack](/slack) and the #innersource-working-group channel
+- Watch the [introductory video](https://github.com/InnerSourceCommons/innersource-working-group/tree/main#recording)
+- Read through the group's [Website](https://innersourcecommons.github.io/innersource-working-group/)
+- Add the [InnerSource Working Group meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=Nzd2cmJzOTJuaGVvZjQyb3U4NmpybjBtcXBfMjAyNjA4MTdUMTUwMDAwWiBjXzYyNjk0ZjQxNDA1NWFjNTY5ZTVjYjEyZGFmYmIwODkwY2EyMmYzNjQwYjE3N2E0YjEwYjUzMTcxZmJjOWJkZDRAZw&tmsrc=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4%40group.calendar.google.com&scp=ALL) to your calendar and plan to attend regularly
 - Review and comment on one of the no-status [Challenges from our Kanban board](https://github.com/orgs/InnerSourceCommons/projects/4/views/1)
 
 ## Patterns Working Group
@@ -150,21 +150,21 @@ You have time and skills and want to make a difference. Jump in:
 - Begin to connect with areas that align most with your interests:
 
 
-## ISPO Working Group
+## InnerSource Working Group
 
-**Description:** This working group is for those who are managing InnerSource projects, working in established ISPOs, or looking to start an ISPO in their company. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
+**Description:** This working group is for InnerSource practitioners. They may have experience to share with others, or they may be looking for guidance and advice. This group meets biweekly in APAC and NA Time Zones and collaborates asynchronously on GitHub and [Slack](/slack).
 
-- Join [Slack](/slack) and the [ISPO working group channel](https://innersourcecommons.slack.com/archives/C04DT6NQX7G)
+- Join [Slack](/slack) and the [InnerSource working group channel](https://innersourcecommons.slack.com/archives/C04DT6NQX7G)
 - Watch the [introductory video](https://www.youtube.com/watch?v=r8Ce7GlwBeA) 
-- Read through the group’s [Website](https://innersourcecommons.github.io/ispo-working-group/)
-- Add the [ISPO Working Group meeting](https://calendar.google.com/calendar/u/0/embed?src=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4@group.calendar.google.com) to your calendar and plan to attend regularly
+- Read through the group's [Website](https://innersourcecommons.github.io/innersource-working-group/)
+- Add the [InnerSource Working Group meeting](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=Nzd2cmJzOTJuaGVvZjQyb3U4NmpybjBtcXBfMjAyNjA4MTdUMTUwMDAwWiBjXzYyNjk0ZjQxNDA1NWFjNTY5ZTVjYjEyZGFmYmIwODkwY2EyMmYzNjQwYjE3N2E0YjEwYjUzMTcxZmJjOWJkZDRAZw&tmsrc=c_62694f414055ac569e5cb12dafbb0890ca22f3640b177a4b10b53171fbc9bdd4%40group.calendar.google.com&scp=ALL) to your calendar and plan to attend regularly
 - Review and comment on the no-status [Challenges from our Kanban board](https://github.com/orgs/InnerSourceCommons/projects/4/views/1)
 
 
 After a few months:
-- Volunteer for [one of the roles](https://github.com/InnerSourceCommons/ispo-working-group/tree/main/roles) in the meeting, attend regularly
-- [Contribute](https://github.com/InnerSourceCommons/ispo-working-group/blob/main/CONTRIBUTING.md#lead-or-make-project-contributions) to an open project on the ISPO [list of open projects board](https://github.com/InnerSourceCommons/ispo-working-group/projects?query=is%3Aopen)
-- [Contribute to the documentation or ISPO](https://github.com/InnerSourceCommons/ispo-working-group/blob/main/CONTRIBUTING.md#to-add-documentation-to-this-repository-and-the-corresponding-website) Working Group website
+- Volunteer for [one of the roles](https://github.com/InnerSourceCommons/innersource-working-group/tree/main/roles) in the meeting, attend regularly
+- [Contribute](https://github.com/InnerSourceCommons/innersource-working-group/blob/main/CONTRIBUTING.md#lead-or-make-project-contributions) to an open project on the InnerSource Working Group [list of open projects board](https://github.com/InnerSourceCommons/innersource-working-group/projects?query=is%3Aopen)
+- [Contribute to the documentation](https://github.com/InnerSourceCommons/innersource-working-group/blob/main/CONTRIBUTING.md#to-add-documentation-to-this-repository-and-the-corresponding-website) for the InnerSource Working Group website
 - Open a new challenge on the [kanban board](https://github.com/orgs/InnerSourceCommons/projects/4/views/1)
 
 ## Patterns Working Group

--- a/content/fr/community/_index.md
+++ b/content/fr/community/_index.md
@@ -103,14 +103,14 @@ title: "Communauté"
   </div>
 </section>
 
-<section class="section bg-light">
+<section class="section bg-light" id="iswg">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-6 order-2 order-md-1">
-        <p class="section-title h2">Groupe de travail sur les ISPOs</p>
-        <p>Le groupe de travail sur les InnerSource Program Offices (ISPOs) produit des travaux pour initialiser, enseigner et faire passer l'InnerSource à l'échelle dans les entreprises. Le groupe organise des réunions régulièrement, mais la plupart du travail est fait en asynchrone sur <a href="https://github.com/InnerSourceCommons/ispo-working-group" target="_blank">GitHub</a>.
+        <p class="section-title h2">Groupe de travail InnerSource</p>
+        <p>Le groupe de travail InnerSource soutient les praticiens de l'InnerSource avec les ressources nécessaires pour s'établir, enseigner et faire passer l'InnerSource à l'échelle dans leurs entreprises respectives. Le groupe organise des réunions régulièrement, mais la plupart du travail est fait en asynchrone sur <a href="https://github.com/InnerSourceCommons/innersource-working-group" target="_blank">GitHub</a>.
         </p>
-        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/> ispo-working-group</a>
+        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/>innersource-working-group</a>
       </div>
       <div class="col-md-5 order-1 order-md-2 mb-4 mb-md-0">
         <img src="/images/community/cuate.png" class="img-fluid">

--- a/content/ja/community/_index.md
+++ b/content/ja/community/_index.md
@@ -102,6 +102,22 @@ title: "コミュニティ"
   </div>
 </section>
 
+<section class="section bg-light" id="iswg">
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-md-6 order-2 order-md-1">
+        <p class="section-title h2">InnerSourceワーキンググループ</p>
+        <p>InnerSourceワーキンググループは、InnerSourceプラクティショナーが自社でInnerSourceを確立し、教育し、スケールするために必要な資料を提供します。グループは定期的にミーティングを行いますが、ほとんどの作業は<a href="https://github.com/InnerSourceCommons/innersource-working-group" target="_blank">GitHub</a>上で非同期的に行われています。
+        </p>
+        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/>innersource-working-group</a>
+      </div>
+      <div class="col-md-5 order-1 order-md-2 mb-4 mb-md-0">
+        <img src="/images/community/cuate.png" class="img-fluid">
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="section bg-light">
   <div class="container">
     <div class="row align-items-center">

--- a/content/pt-br/community/_index.md
+++ b/content/pt-br/community/_index.md
@@ -105,16 +105,14 @@ ation.png" class="img-fluid">
   </div>
 </section>
 
-<section class="section bg-light">
+<section class="section bg-light" id="iswg">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-md-6 order-2 order-md-1">
-        <p class="section-title h2">Grupo de Trabalho ISPO</p>
-        <p>O Grupo
-
- de Trabalho ISPO oferece suporte aos Escritórios de Programa InnerSource (ISPOs) com os materiais necessários para se estabelecerem, ensinarem e escalarem o InnerSource em suas respectivas empresas. O grupo realiza reuniões regulares, mas a maior parte do trabalho é feita de forma assíncrona no <a href="https://github.com/InnerSourceCommons/ispo-working-group" target="_blank">GitHub</a>.
+        <p class="section-title h2">Grupo de Trabalho InnerSource</p>
+        <p>O Grupo de Trabalho InnerSource oferece suporte aos praticantes de InnerSource com os materiais necessários para se estabelecerem, ensinarem e escalarem o InnerSource em suas respectivas empresas. O grupo realiza reuniões regulares, mas a maior parte do trabalho é feita de forma assíncrona no <a href="https://github.com/InnerSourceCommons/innersource-working-group" target="_blank">GitHub</a>.
         </p>
-        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/> ispo-working-group</a>
+        <a href="/slack" class="btn btn-primary btn-sm text-lowercase"><img src="/images/slack.png" class="slack-tiny mr-1"/>innersource-working-group</a>
       </div>
       <div class="col-md-5 order-1 order-md-2 mb-4 mb-md-0">
         <img src="/images/community/cuate.png" class="img-fluid">


### PR DESCRIPTION
- Update EN community page, quick-start guide, and board bios
- Update FR, JA, and PT-BR community pages
- Update GitHub and Slack links to innersource-working-group