### PR TITLE
Fix 404 on localized "Join us on Slack" menu links

### DIFF
--- a/config/_default/menus.de.yaml
+++ b/config/_default/menus.de.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.es.yaml
+++ b/config/_default/menus.es.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.fr.yaml
+++ b/config/_default/menus.fr.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.it.yaml
+++ b/config/_default/menus.it.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.ja.yaml
+++ b/config/_default/menus.ja.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.pt-br.yaml
+++ b/config/_default/menus.pt-br.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.ru.yaml
+++ b/config/_default/menus.ru.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups

--- a/config/_default/menus.zh.yaml
+++ b/config/_default/menus.zh.yaml
@@ -16,7 +16,7 @@ main:
     parent: start-here
     weight: 3
   - name: Join our Chat on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: start-here
     weight: 4
   - name: Join our Mailing List
@@ -58,7 +58,7 @@ main:
     weight: 3
     identifier: community
   - name: Join us on Slack
-    URL: /slack
+    URL: https://innersourcecommons.org/slack
     parent: community
     weight: 1
   - name: Working Groups


### PR DESCRIPTION
## What

The **"Join us on Slack"** navigation link (and the **"Join our Chat on Slack"** link under *Start Here*) returned a **404** in every non-English locale.

## Why

The menu links pointed at the relative path `/slack`.
The nav template renders every relative menu URL through Hugo's `absLangURL`, which prepends the active language prefix - so in each non-English locale the link resolved to `/<lang>/slack` (e.g. `/pt-br/slack`, `/de/slack`, `/ja/slack`).
The Slack join page exists only once, at the site root (`/slack`, a redirect to the Slack invite), so every localized variant 404'd.

English was unaffected because it has no language prefix, so its `/slack` link already resolved to the real page.

## Fix

Point the two Slack menu links at the absolute `https://innersourcecommons.org/slack` in all eight non-English menus (`de`, `es`, `fr`, `it`, `ja`, `pt-br`, `ru`, `zh`).
`absLangURL` passes absolute URLs through unchanged, so each locale now links to the working join page, and the invite link stays single-sourced in the English `/slack` redirect page.
English `menus.en.yaml` is left as-is.

## Origin

Reported in the community Slack `#general` by Shingo Oidate for the `pt-br` locale; verified the same 404 on `de`, `es`, `fr`, `it`, `ja`, `ru`, and `zh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
