### PR TITLE
sponsors: add Airbus as a Supporter

### DIFF
--- a/content/en/about/sponsors.md
+++ b/content/en/about/sponsors.md
@@ -30,6 +30,7 @@ subtitle: "Our Partners are organizations helping to lead the InnerSource moveme
   <div class="container">
     <div class="row justify-content-center">
       <!-- {{< company name="Adeo" image="/images/logos/adeo-supporters.png" >}}{{< /company >}} -->
+      {{< company name="Airbus" image="/images/logos/airbus.png" >}}{{< /company >}}
       {{< company name="Bosch" image="/images/logos/bosch.png" >}}{{< /company >}}
       {{< company name="Capital One" image="/images/logos/capital-one.png" >}}{{< /company >}}
       {{< company name="Comcast" image="/images/logos/comcast.png" >}}{{< /company >}}


### PR DESCRIPTION
## What

Adds **Airbus** to the sponsors page under **Supporters**, using the existing `/images/logos/airbus.png` logo.

Airbus is sponsoring **InnerSource Summit 2026** at the Silver level ($5,000), PO issued and acknowledged.
Russ committed to Frédéric Sicot (our Airbus champion) that we'd list Airbus as a sponsor on the site.

## One thing to confirm

I placed Airbus under **Supporters** (the tier that fits a Silver / Summit-level sponsorship).
If you'd rather it sit under **Partners**, it's a one-line move between the two sections.

## Preview

Airbus appears first in the Supporters row (alphabetical), rendered from the existing logo asset - no new image needed.
