### PR TITLE
Summit 2026: add sponsor section (Airbus, first Silver sponsor)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,5 +5,5 @@ Hugo static site for the InnerSource Commons Foundation.
 ## When modifying pages
 
 - **Preview locally before opening a PR**: `hugo server --buildDrafts --buildFuture`, then check every page you touched at `http://localhost:1313/...`. If `hugo` isn't on `PATH`, it's typically installed via `winget install Hugo.Hugo.Extended`.
-- **Attach a screenshot of every changed page to the PR description**, under a "Screenshots" section — a markdown or CSS diff doesn't show how the page actually renders, and layout/spacing/image-crop issues only show up visually.
+- **Attach a full-page screenshot of every changed page to the PR description**, under a "Screenshots" section — capture the whole page top to bottom, not just the changed area, so each change is reviewed in the context of how it sits within the overall page. A markdown or CSS diff doesn't show how the page actually renders, and layout/spacing/image-crop issues only show up visually.
 - Run a full `hugo` build (not just the dev server) at least once before opening the PR — the dev server's incremental rebuild can miss errors a clean build catches.

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -80,6 +80,9 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 ### Our Sponsors
 <br />
 
+<p class="text-center">The InnerSource Summit is made possible by the generosity of its sponsors - organizations that believe in open collaboration and invest in the community that practices it. We're grateful to have them with us for Summit 2026.</p>
+<br />
+
 <div class="container text-center">
   <h4>Silver Sponsors</h4>
 </div>

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -77,6 +77,24 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 <br />
 <br />
 
+### Our Sponsors
+<br />
+
+<div class="container text-center">
+  <h4>Silver Sponsors</h4>
+</div>
+
+<div class="container">
+  <div class="row justify-content-center">
+    {{< company name="Airbus" image="/images/logos/airbus.png" >}}{{< /company >}}
+  </div>
+</div>
+
+<!-- Bronze Sponsors: when the first Bronze sponsor joins, add a centered "Bronze Sponsors" h4 heading followed by a row of company logo cards, mirroring the Silver block above. -->
+
+<br />
+<br />
+
 **Talk to us now on info@innersourcecommons.org to find out how you can be part of this year’s summit or fill out the following forms:
 <br />
 <!-- [Expression of Interest form](https://docs.google.com/forms/d/e/1FAIpQLSfPV4TURwC9czP5Sn5AfXY4E7QGRYHdjZgSKExrL7b5pjGtFg/viewform) -->

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -80,7 +80,7 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 ### Our Sponsors
 <br />
 
-<p class="text-center">The InnerSource Summit is made possible by the generosity of its sponsors - organizations that believe in open collaboration and invest in the community that practices it. We're grateful to have them with us for Summit 2026.</p>
+<p>The InnerSource Summit is made possible by the generosity of its sponsors - organizations that believe in open collaboration and invest in the community that practices it. We're grateful to have them with us for Summit 2026.</p>
 <br />
 
 <div class="container text-center">

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -84,11 +84,15 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
   <h4>Silver Sponsors</h4>
 </div>
 
-<div class="container">
+<div class="container summit-sponsors">
   <div class="row justify-content-center">
-    {{< company name="Airbus" image="/images/logos/airbus.png" >}}{{< /company >}}
+    {{< company name="Airbus" image="/images/logos/airbus.png" url="https://www.airbus.com" >}}{{< /company >}}
   </div>
 </div>
+
+<style>
+.summit-sponsors .feature-card { background-color: transparent !important; }
+</style>
 
 <!-- Bronze Sponsors: when the first Bronze sponsor joins, add a centered "Bronze Sponsors" h4 heading followed by a row of company logo cards, mirroring the Silver block above. -->
 

--- a/layouts/shortcodes/company.html
+++ b/layouts/shortcodes/company.html
@@ -1,9 +1,16 @@
 <div class="col-md-4 col-sm-6 mb-4">
   <div class="feature-card bg-light text-center mb-0">
+    {{ if .Get "url" }}
+    <a href="{{ .Get "url" }}" target="_blank" rel="noopener" class="h-150 d-flex align-items-center justify-content-center mb-0 company-logo-box">
+      <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" title="{{ .Get "name" }}" class="mh-150">
+      <div>{{ .Get "name" }}</div>
+    </a>
+    {{ else }}
     <div class="h-150 d-flex align-items-center justify-content-center mb-0 company-logo-box">
       <img src="{{ .Get "image" }}" alt="{{ .Get "name" }}" title="{{ .Get "name" }}" class="mh-150">
       <div>{{ .Get "name" }}</div>
     </div>
+    {{ end }}
     <div class="cite-icons mt-1 align-items-center justify-content-center mb-0">
       {{ if (not (eq (trim .Inner "\n ") "")) }}<a href="#" class="cite-link" data-link="{{ urlize (.Get "name")}}-cite"><i class="ti-align-right mb-0 mr-1"></i></a>{{ end }}
       {{ if .Get "video" }}<a href="{{ .Get "video" }}" target="_blank"><i class="ti-video-camera mb-0 mr-1 ml-1"></i></a>{{ end }}


### PR DESCRIPTION
## What

Adds an **"Our Sponsors"** section to the [InnerSource Summit 2026](https://innersourcecommons.org/events/isc-2026/) event page, with a **Silver Sponsors** tier showing **Airbus** as the first Silver sponsor.

- Uses the existing `/images/logos/airbus.png` logo via the standard `{{< company >}}` shortcode.
- Placed after the keynote speakers and before the "get involved" forms.
- Leaves a commented scaffold for a **Bronze Sponsors** tier to fill in as those sponsors come on board.

## Why

Airbus is sponsoring Summit 2026 at the Silver level ($5,000) - PO issued and acknowledged.
This is the event-page home for summit sponsors (supersedes #1221, which had added Airbus to the year-round community Supporters list - the wrong place for an event sponsor).

## Notes

- `hugo` builds clean and the section renders (Our Sponsors → Silver Sponsors → Airbus logo card).
- Draft until you confirm the placement and tier styling on the deploy preview.

## Screenshots

<img width="1272" height="3380" alt="summit-fullpage" src="https://github.com/user-attachments/assets/281f530b-9b52-4135-a3a0-3f5550a156d4" />
