### PR TITLE
Summit 2026: Get Involved cards + top CTA for the participation forms

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -13,6 +13,7 @@ bigHeading: true
 <br />
 
 <p class="text-center"><strong>This is a fully virtual event - join online from anywhere in the world.</strong></p>
+<p class="text-center mt-4"><a href="#get-involved" class="btn btn-primary primary-link">Get involved in Summit 2026</a></p>
 <br />
 <br />
 
@@ -102,11 +103,36 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 <br />
 <br />
 
-**Talk to us now on info@innersourcecommons.org to find out how you can be part of this year’s summit or fill out the following forms:
 <br />
-<!-- [Expression of Interest form](https://docs.google.com/forms/d/e/1FAIpQLSfPV4TURwC9czP5Sn5AfXY4E7QGRYHdjZgSKExrL7b5pjGtFg/viewform) -->
-[CFP Form](https://docs.google.com/forms/d/e/1FAIpQLSc7BunGnu-LW5PsTtmtvna5xn_F5nkZockHJvskhnDu_5it5Q/viewform?usp=dialog)
 <br />
-[Sponsorship Form](https://docs.google.com/forms/d/e/1FAIpQLSdhE4k3-9hk0rPxBQBDfx293Xtiyuxyk55I9Kr7EDxrmVFJug/viewform?usp=dialog)
-<br />
-[Volunteer Form](https://docs.google.com/forms/d/e/1FAIpQLScJl68JOJla9luOd4lRIvLCRMCHtKQY_ReW_KQC4HO_pdXd5Q/viewform?usp=dialog)
+
+<div class="row justify-content-center" id="get-involved">
+  <div class="col-12 text-center mb-4">
+    <p class="mt-3 h1">Get Involved</p>
+    <p>There are several ways to be part of InnerSource Summit 2026. Choose how you'd like to take part, or email us at <a href="mailto:info@innersourcecommons.org">info@innersourcecommons.org</a> to find out how you can be part of this year's summit.</p>
+  </div>
+  <div class="col-md-4 col-sm-6 mb-4">
+    <div class="feature-card text-center bg-light h-100">
+      <i class="ti-microphone mb-3"></i>
+      <h4 class="mb-2">Speak at the Summit</h4>
+      <p>Share your InnerSource story or expertise with a global audience through our Call for Proposals.</p>
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSc7BunGnu-LW5PsTtmtvna5xn_F5nkZockHJvskhnDu_5it5Q/viewform?usp=dialog" class="btn btn-primary primary-link btn-sm" target="_blank" rel="noopener">Submit a Talk</a>
+    </div>
+  </div>
+  <div class="col-md-4 col-sm-6 mb-4">
+    <div class="feature-card text-center bg-light h-100">
+      <i class="ti-heart mb-3"></i>
+      <h4 class="mb-2">Sponsor the Summit</h4>
+      <p>Put your organization in front of the global InnerSource community and help make the summit possible.</p>
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSdhE4k3-9hk0rPxBQBDfx293Xtiyuxyk55I9Kr7EDxrmVFJug/viewform?usp=dialog" class="btn btn-primary primary-link btn-sm" target="_blank" rel="noopener">Become a Sponsor</a>
+    </div>
+  </div>
+  <div class="col-md-4 col-sm-6 mb-4">
+    <div class="feature-card text-center bg-light h-100">
+      <i class="ti-hand-open mb-3"></i>
+      <h4 class="mb-2">Volunteer</h4>
+      <p>Lend a hand behind the scenes and help bring the around-the-world summit to life.</p>
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLScJl68JOJla9luOd4lRIvLCRMCHtKQY_ReW_KQC4HO_pdXd5Q/viewform?usp=dialog" class="btn btn-primary primary-link btn-sm" target="_blank" rel="noopener">Volunteer</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## What & why

Jeff raised in #summit2026planning that the CFP, sponsorship, and volunteer forms on the [Summit 2026 page](https://innersourcecommons.org/events/isc-2026/) are hard to find - they were plain text links at the very bottom, and he's had to tell people to scroll all the way down to reach them.

This makes the forms easy to find in two ways:

- **A "Get Involved" card section** - the three forms become cards (Speak / Sponsor / Volunteer), each with an icon, a short description, and a button to its form, styled to match the cards on the [community page](https://innersourcecommons.org/community/).
- **A top-of-page button** - "Get involved in Summit 2026" sits right under the event summary and jumps straight to the section, so nobody has to scroll to find it.

Only the English page (`content/en/events/isc-2026.md`) has a 2026 summit entry, so there are no translations to update.

## Note

The card and CTA buttons use the theme's `primary-link` class alongside `btn btn-primary`. Inside the event layout's `.content` wrapper, the site-wide link-color rule would otherwise paint the button text the same teal as its background (invisible); `primary-link` forces white text, the same pattern already used on the past-summits and sponsors pages.

## Screenshots

![Full-page preview of the updated Summit 2026 page](https://github.com/user-attachments/assets/86e01012-29fd-48a6-9b6f-c777b09ae5bb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
