### PR TITLE
Add SAP as a Summit 2026 Silver Sponsor

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -91,6 +91,7 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 <div class="container summit-sponsors">
   <div class="row justify-content-center">
     {{< company name="Airbus" image="/images/logos/airbus.png" url="https://www.airbus.com" >}}{{< /company >}}
+    {{< company name="SAP" image="/images/logos/sap.png" url="https://www.sap.com" >}}{{< /company >}}
   </div>
 </div>
 


### PR DESCRIPTION
## What & why

SAP signed and was invoiced for a $5,000 Silver Sponsorship of [InnerSource Summit 2026](https://innersourcecommons.org/events/isc-2026/) - the agreement is fully countersigned and the invoice is out. This adds SAP's logo to the Silver Sponsors row on the Summit 2026 page, alongside Airbus, using the same `{{< company >}}` shortcode and linking to https://www.sap.com. The SAP logo asset already exists in the repo (`static/images/logos/sap.png`, used on the general [sponsors page](https://innersourcecommons.org/about/sponsors/)), so no new asset was needed.

Only the English page (`content/en/events/isc-2026.md`) has a 2026 summit entry, so there are no translations to update.

## Screenshots

![Full-page preview of the updated Summit 2026 page with SAP added to Silver Sponsors](https://github.com/user-attachments/assets/30bd97a3-53d1-4bff-ae07-c507531ed08a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
