### PR TITLE
Fix Summit 2026 announcement listing and image sizing

### DIFF
--- a/layouts/announcements/list.html
+++ b/layouts/announcements/list.html
@@ -5,7 +5,10 @@
 <section class="section">
   <div class="container">
     <div class="row">
-      {{ range first 1 (where .Data.Pages.ByDate.Reverse ".Params.featured" "==" true) }}
+      {{ $pages := .Data.Pages.ByDate.Reverse }}
+      {{ $hero := "" }}
+      {{ range first 1 (where $pages ".Params.featured" "==" true) }}
+      {{ $hero = . }}
       <div class="col-12 mb-5 pb-5">
         <div class="row align-items-center">
           <div class="col-md-6 mb-4 mb-md-0">
@@ -24,7 +27,8 @@
         </div>
       </div>
       {{ end }}
-      {{ range where .Data.Pages.ByDate.Reverse ".Params.featured" "!=" true }}
+      {{ range $pages }}
+      {{ if ne . $hero }}
       <div class="col-lg-4 col-sm-6 mb-5 event-card">
         <div class="card border-0">
           <a href="{{.Permalink}}">
@@ -40,6 +44,7 @@
           </div>
         </div>
       </div>
+      {{ end }}
       {{ end }}
     </div>
   </div>

--- a/layouts/announcements/single.html
+++ b/layouts/announcements/single.html
@@ -14,7 +14,7 @@
         </div>
         {{ else }}
         <h2 class="mb-4">{{ .Title }}</h2>
-        <img src="{{ .Params.image | absURL }}" alt="{{ .Title }}" class="img-fluid w-100 rounded mb-4 mt-1">
+        <img src="{{ .Params.image | absURL }}" alt="{{ .Title }}" class="img-fluid rounded mb-4 mt-1 d-block mx-auto" style="max-height: 420px; width: auto;">
         {{ end }}
         <div class="content">{{.Content}}</div>
         <div class="fw-500 mb-4 fl-r"><i class="ti-calendar text-dark me-1"></i> {{ .Params.Date.Format "January 2, 2006" }}</div>


### PR DESCRIPTION
## What this fixes

Two problems Russell spotted after the David Spinks keynote announcement went live.

### 1. Both keynote announcements now appear on the listing

The announcements listing rendered only the single most-recent featured post as the hero, and the card grid below it only included posts where `featured != true`.
When David Spinks (Aug 25) became the newest featured post, Scott Hanselman (Aug 6, also featured) fell out of both ranges and disappeared from the listing entirely.

The listing now renders the most-recent announcement as the hero and *every other announcement* as a card.
So both keynotes show today - David as the hero, Scott as a card - and any number of future featured posts self-manage (newest as hero, the rest as cards) with no per-post front-matter toggling.

### 2. Announcement header image no longer stretches to full width

The announcement template stretched the front-matter `image` to the full container width.
Scott's landscape headshot (2560x1707) looked fine that way, but David's square, lower-res source (400x400) rendered as an enormous square.

The image is now height-capped at 420px and centered, with width following naturally.
David's square renders at a sensible ~400px; Scott's landscape renders centered and height-capped.
This is a shared template, so both announcement pages get the same treatment.

## Screenshots

### Announcements listing - both keynotes visible (David hero, Scott card)

![Announcements listing showing David Spinks as hero and Scott Hanselman as a card](https://github.com/user-attachments/assets/0a91a3dc-5e58-424d-88d2-0b4893c4f94b)

### David Spinks announcement - photo centered, no longer stretched

![David Spinks announcement page with the headshot centered and height-capped](https://github.com/user-attachments/assets/0d6c6c41-c540-4119-9441-e3a50546767e)

### Scott Hanselman announcement - photo centered and height-capped

![Scott Hanselman announcement page with the headshot centered and height-capped](https://github.com/user-attachments/assets/0698e602-546b-49cb-a090-b0980fa26add)
