### PR TITLE
Use David Spinks's approved bio copy on event and announcement pages

### DIFF
--- a/content/en/about/announcements/2026-08-david-spinks-keynote.md
+++ b/content/en/about/announcements/2026-08-david-spinks-keynote.md
@@ -8,19 +8,19 @@ featured: true
 type: "announcements"
 ---
 
-InnerSource Commons is delighted to announce that David Spinks, cofounder of CMX and author of *The Business of Belonging*, will deliver a keynote at [InnerSource Summit 2026](/events/isc-2026/), taking place on Thursday, November 12, 2026.
+InnerSource Commons is delighted to announce that David Spinks, a Community Leadership Coach, author of *The Business of Belonging*, and former cofounder of CMX, will deliver a keynote at [InnerSource Summit 2026](/events/isc-2026/), taking place on Thursday, November 12, 2026.
 
 InnerSource Summit 2026 is a 22-hour global virtual event that follows the sun across every timezone, bringing together practitioners, engineering leaders, researchers, and open collaboration advocates from around the world to share experiences, innovations, and best practices in InnerSource.
 
-David Spinks is one of the world's foremost voices on community building. Over 15 years he has advised and trained hundreds of organizations - including Facebook, Salesforce, Airbnb, and Google - on how to build thriving communities, work he distilled into his acclaimed book *The Business of Belonging: How to Make Community Your Competitive Advantage* and his Masters of Community podcast.
+David Spinks is widely recognized as one of the world's foremost experts on community strategy. From founding his first online community at age 14 to training community teams at tech giants like Google, Meta, Udemy, Waze, and Airbnb, Spinks has spent his career proving that community is a core driver of collaborative business success. As the cofounder of CMX, he grew the platform into a premier network of over 20,000 community professionals. David is the author of *The Business of Belonging*, which has been read by thousands of business leaders around the world, and translated into multiple languages.
 
-"InnerSource is, at its heart, about community - people across an organization choosing to collaborate in the open rather than in silos," said Russ Rutledge, Executive Director of InnerSource Commons. "David Spinks is an expert in showing how communities create real value. I can't wait for our attendees to learn from him."
+"InnerSource is fundamentally about people - sharing knowledge and working well together inside a company," said Russ Rutledge, Executive Director of InnerSource Commons. "David has spent his career figuring out what makes communities work, and that experience will be invaluable for attendees who are trying to grow InnerSource in their own organizations."
 
 Additional keynote speakers, session agendas, and registration details will be rolled out over the coming months.
 
 ### About David Spinks
 
-David Spinks is the cofounder of CMX, the leading community for community professionals, and the author of *The Business of Belonging: How to Make Community Your Competitive Advantage*. He launched his first online community as a teenager and has since advised and trained hundreds of organizations on community strategy, including Facebook, Salesforce, Airbnb, and Google. He hosts the Masters of Community podcast and today coaches community leaders on creating genuine belonging at scale.
+David Spinks is a Community Leadership Coach who works with founders, execs, and teams to help them become the leaders their communities need to thrive. He was a cofounder of CMX, the world's largest network for community professionals. He is the author of *The Business of Belonging*, and a premier voice in the community-driven business movement who advises Fortune 500 companies on community architecture and continues to inspire global organizations to build deeper, more meaningful collaborative networks through his consulting, speaking, and writing.
 
 ### About InnerSource Commons
 

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -85,7 +85,7 @@ Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/Git
 
 **David Spinks**
 
-David Spinks is one of the world's foremost voices on community building. He is the cofounder of CMX, the leading community for community professionals, and the author of *The Business of Belonging: How to Make Community Your Competitive Advantage*. Over 15 years he has advised and trained hundreds of organizations - including Facebook, Salesforce, Airbnb, and Google - on how to build thriving communities, and he hosts the Masters of Community podcast. Today he coaches community leaders on creating genuine belonging at scale.
+David Spinks is a Community Leadership Coach who works with founders, execs, and teams to help them become the leaders their communities need to thrive. He was a cofounder of CMX, the world's largest network for community professionals. He is the author of *The Business of Belonging*, and a premier voice in the community-driven business movement who advises Fortune 500 companies on community architecture and continues to inspire global organizations to build deeper, more meaningful collaborative networks through his consulting, speaking, and writing.
 
 </div>
 </div>


### PR DESCRIPTION
## What this changes

David Spinks reviewed and approved his own promotional copy with Jeff over email, editing it in the shared Google Doc and correcting factual details the site's draft had wrong.
This swaps the earlier draft copy for David's approved wording in both places he appears on the site: the [Summit 2026 event page](https://innersourcecommons.org/events/isc-2026/) speaker bio and his [dedicated announcement post](https://innersourcecommons.org/about/announcements/2026-08-david-spinks-keynote/).

### Corrections from David's approved copy

- He is a **Community Leadership Coach** and a **former** cofounder of CMX, not a current cofounder.
- The companies he has trained community teams at are **Google, Meta, Udemy, Waze, and Airbnb**; CMX is described as a network of **over 20,000 community professionals**.
- He founded his first online community **at age 14**.
- The "About David Spinks" paragraph and the keynote quote now use his approved language.

The keynote quote attributed to Russ was also replaced with the version from the approved doc - flagging that for a look, since it's Russ's own words.

## Screenshots

### David Spinks announcement post - approved copy

![David Spinks announcement post with his approved bio copy](https://github.com/user-attachments/assets/03931062-4f86-4687-b831-e4719078d229)

### Summit 2026 event page - approved speaker bio

![Summit 2026 event page speaker bios with David Spinks's approved copy](https://github.com/user-attachments/assets/1618dd2b-3916-46cf-9f45-dfe0d5264b1c)
