### PR TITLE
Add 4 newly signed 2026 Foundation members to the Members page

### DIFF
--- a/content/en/about/members.md
+++ b/content/en/about/members.md
@@ -33,12 +33,14 @@ Membership in the InnerSource Commons Foundation requires nomination and electio
 * Dmitrii Sugrobov
 * Fei Wan
 * Fernando Correa
+* Frédéric Sicot Mouret
 * Georg Gr&#x00FC;tter
 * Guilherme Dellagustin
 * Igor Zubaiurre 
 * Isabel Drost-Fromm
 * Jacob Green
 * Jeff Bailey
+* Jenna Ritten
 * Jerry Tan
 * Johannes Tigges
 * Justin Gosses
@@ -46,12 +48,14 @@ Membership in the InnerSource Commons Foundation requires nomination and electio
 * Klaas-Jan Stol
 * Matt Cobby
 * Maximilian Capraro
+* Micaela Eller
 * Mishari Muqbil
 * Niall Maher
 * Regina Nkenchor
 * Russell Rutledge
 * Ryo Ashikawa
 * Sebastian Spier
+* Shingo Oidate
 * Shoma Kubo
 * Silona Bonewald
 * Thomas Froment


### PR DESCRIPTION
## Summary
- Adds the 4 newest 2026-elected Foundation members to the Members page, now that their signed applications are in: Frédéric Sicot Mouret, Jenna Ritten, Micaela Eller, Shingo Oidate.
- Inserted alphabetically by first name, matching the existing list's ordering.

## Screenshots

![Members page, full page](https://github.com/user-attachments/assets/be5c290d-19b5-4911-8e19-0e33b2c8aba0)

## Test plan
- [x] `hugo --gc` full build succeeds with no errors.
- [x] `hugo server --buildDrafts --buildFuture` and visually confirmed all 4 names render correctly on `/about/members/`.
