### PR TITLE
CLAUDE.md: attach the PR screenshot via the browser, never commit it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,6 @@ Hugo static site for the InnerSource Commons Foundation.
 
 - **Preview locally before opening a PR**: `hugo server --buildDrafts --buildFuture`, then check every page you touched at `http://localhost:1313/...`. If `hugo` isn't on `PATH`, it's typically installed via `winget install Hugo.Hugo.Extended`.
 - **Attach a full-page screenshot of every changed page to the PR description**, under a "Screenshots" section — capture the whole page top to bottom, not just the changed area, so each change is reviewed in the context of how it sits within the overall page. A markdown or CSS diff doesn't show how the page actually renders, and layout/spacing/image-crop issues only show up visually.
+  - Attach it through the browser: open the PR on github.com and drop the image straight into the description, the same as dragging a file into the comment box, so GitHub stores it as a `user-attachments` upload.
+    Never commit the screenshot into the repo as a file. It is a review artifact, not site content, and a committed binary stays in the repo's history for good.
 - Run a full `hugo` build (not just the dev server) at least once before opening the PR — the dev server's incremental rebuild can miss errors a clean build catches.


### PR DESCRIPTION
The screenshot requirement said *what* to attach but not *how*. This adds that the screenshot is uploaded to the PR through the browser (GitHub's own `user-attachments` flow, the same as dragging a file into the comment box), and never committed into the repo as a file - it's a review artifact, not site content, and a committed binary stays in the repo's history for good.

Tool-agnostic on purpose: a human drags the file in; an AI session drives the browser (and one equipped with browser-chauffeur will route that browser work through it automatically). No changed site page, so no screenshot needed on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)