### PR TITLE
Embed Summit 2026 ticket sales: Pretix widget + homepage hero CTA

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -11,7 +11,7 @@ fetchYoutubeVideos: true
 				<h1 style="font-size: 40px; color: white; text-align: left; margin: 0px">Welcome to the InnerSource Commons</h1>
 			</div>
 			<div class="col-lg-4 col-md-6 col-sm-6" style="margin-top: 40px;">
-      <!-- {{ < upcoming-event-card style="banner" > }} -->
+      {{< summit-event-card >}}
 			</div>
 		</div>
 	</div>

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -20,9 +20,8 @@ pretixWidget: true
 <noscript>
 <div class="pretix-widget">
 <div class="pretix-widget-info-message">
-JavaScript is disabled. Please go to
-<a href="https://pretix.eu/InnerSource/Summit26/">pretix.eu/InnerSource/Summit26/</a>
-to buy tickets.
+JavaScript is disabled. Please
+<a href="https://pretix.eu/InnerSource/Summit26/">buy tickets on Pretix</a>.
 </div>
 </div>
 </noscript>

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -5,6 +5,7 @@ image: "/images/events/2026-summit-banner.png"
 date: 2026-11-12
 publishDate: 2026-04-09
 bigHeading: true
+pretixWidget: true
 ---
 <!-- ### Save the date
 #### 12th November 2026 -->
@@ -13,8 +14,19 @@ bigHeading: true
 <br />
 
 <p class="text-center"><strong>This is a fully virtual event - join online from anywhere in the world.</strong></p>
-<p class="text-center mt-4"><a href="#get-involved" class="btn btn-primary primary-link">Get involved in Summit 2026</a></p>
-<br />
+<div class="mt-4 mb-4" id="tickets">
+<h2 class="text-center">Get your tickets</h2>
+<pretix-widget event="https://pretix.eu/InnerSource/Summit26/"></pretix-widget>
+<noscript>
+<div class="pretix-widget">
+<div class="pretix-widget-info-message">
+JavaScript is disabled. Please go to
+<a href="https://pretix.eu/InnerSource/Summit26/">pretix.eu/InnerSource/Summit26/</a>
+to buy tickets.
+</div>
+</div>
+</noscript>
+</div>
 <br />
 
 On Thursday, November 12th, InnerSource Summit 2026 will unite the global InnerSource community online for a 22-hour around-the-world event spanning every timezone!  We will be featuring the industry’s top speakers, inspiring stories, and cutting-edge ideas shaping the future of collaborative software development. 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -73,4 +73,10 @@
   {{ "<!-- Mastodon verification code -->" | safeHTML }}
   <link href="https://fosstodon.org/@innersource" rel="me">
 
+  {{ if .Params.pretixWidget }}
+  {{ "<!-- pretix ticket widget -->" | safeHTML }}
+  <link rel="stylesheet" type="text/css" href="https://pretix.eu/InnerSource/Summit26/widget/v2.css" crossorigin>
+  <script type="text/javascript" src="https://pretix.eu/widget/v2.en.js" async crossorigin></script>
+  {{ end }}
+
 </head>

--- a/layouts/shortcodes/summit-event-card.html
+++ b/layouts/shortcodes/summit-event-card.html
@@ -1,10 +1,12 @@
 <div style="position: relative; border: none; box-shadow: none;">
   <div
     style="position: absolute; top: 10px; left: 10px; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; color: white; background: rgba(0, 0, 0, 0.5); padding: 4px 8px; border-radius: 2px; z-index: 1;">
-    Upcoming Event</div>
-  <a href="/events/isc-2025/" class="event-link" target="_blank"
+    Tickets on sale</div>
+  <a href="/events/isc-2026/" class="event-link"
     style="text-decoration: none; color: inherit; display: block; border: none;">
-    <img src="/images/events/Summit2025.png"
+    <img src="/images/events/2026-summit-banner.png" alt="InnerSource Summit 2026"
       style="width: 100%; display: block; border: none; margin: 0; border-radius: 6px;">
   </a>
+  <a href="/events/isc-2026/" class="btn btn-primary primary-link btn-sm"
+    style="display: block; margin-top: 10px; text-align: center; font-weight: 600;">Get your tickets for InnerSource Summit 2026</a>
 </div>


### PR DESCRIPTION
## What changed

Two placements for InnerSource Summit 2026 ticket sales:

- **Task A - Summit 2026 page** (`/events/isc-2026/`): the top "Get involved in Summit 2026" button is replaced by the embedded pretix ticket-purchase widget, so visitors buy a ticket without leaving the page. The widget's CSS and JS load in the page head, gated on a new `pretixWidget` frontmatter flag, and a `<noscript>` block links to the pretix hosted page for visitors without JavaScript.
- **Task B - Homepage hero** (`/`): the empty right side of the welcome banner now shows the summit banner image and a "Get your tickets for InnerSource Summit 2026" call to action linking to the event page. This reuses the existing `summit-event-card` shortcode, refreshed from the 2025 summit to 2026.

The bottom "Get Involved" cards (Speak / Sponsor / Volunteer) on the Summit page are unchanged.

## Verification

- Full `hugo` build passes with no new warnings.
- Checked in a local `hugo server` via a real browser: the pretix widget loads live ticket tiers (Early Bird, Community, Corporate, Supported) and is interactive; the hero call to action links to `/events/isc-2026/`; both pages render cleanly at desktop, tablet, and mobile widths.

## Screenshots

### Task B - Homepage hero ticket call to action (`/`)

Close-up of the hero overlay:

<img width="1280" alt="homepage-hero-closeup" src="https://github.com/user-attachments/assets/fd12bd39-14dc-4cc6-a826-e1211c122542" />

Full page:

<img width="1900" height="4259" alt="homepage-full-page" src="https://github.com/user-attachments/assets/3420f89d-799e-4900-b9bb-badeb4fa3077" />

### Task A - Summit 2026 page, pretix widget in place of the button (`/events/isc-2026/`)

Full page:

<img width="1900" height="6516" alt="summit-2026-full-page" src="https://github.com/user-attachments/assets/385882f6-a137-4539-b5b5-46dfd72e9207" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtuJK8c5a2sBCYaofxtUuQ
