### PR TITLE
Remove closed CFP link from Summit 2026 page

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -148,14 +148,6 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
   </div>
   <div class="col-md-4 col-sm-6 mb-4">
     <div class="feature-card text-center bg-light h-100">
-      <i class="ti-microphone mb-3"></i>
-      <h4 class="mb-2">Speak at the Summit</h4>
-      <p>Share your InnerSource story or expertise with a global audience through our Call for Proposals.</p>
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSc7BunGnu-LW5PsTtmtvna5xn_F5nkZockHJvskhnDu_5it5Q/viewform?usp=dialog" class="btn btn-primary primary-link btn-sm" target="_blank" rel="noopener">Submit a Talk</a>
-    </div>
-  </div>
-  <div class="col-md-4 col-sm-6 mb-4">
-    <div class="feature-card text-center bg-light h-100">
       <i class="ti-heart mb-3"></i>
       <h4 class="mb-2">Sponsor the Summit</h4>
       <p>Put your organization in front of the global InnerSource community and help make the summit possible.</p>


### PR DESCRIPTION
## Summary
- The Call for Proposals for Summit 2026 has closed, so this removes the "Speak at the Summit" / "Submit a Talk" tile (and its Google Form link) from the Get Involved section of the event page.

## Test plan
- [x] `hugo --gc` full build succeeds with no errors
- [x] Verified the page renders correctly via local `hugo server` preview (screenshot below)

## Screenshots

<img width="1900" height="6900" alt="isc-2026-fullpage" src="https://github.com/user-attachments/assets/3156ebef-5079-4a73-a6d0-38fe0fe78cef" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
