### PR TITLE
Refine Summit 2026 organizer titles and intro wording

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -187,7 +187,7 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
   <div class="organizer">
     <img src="/images/about/Russell_Rutledge.jpg" alt="Russell Rutledge" />
     <span class="organizer-name">Russell Rutledge</span>
-    <span class="organizer-role">Sponsorship Director</span>
+    <span class="organizer-role">Executive Director</span>
   </div>
   <div class="organizer">
     <img src="/images/events/organizer-placeholder.svg" alt="Winner Bright" />

--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -170,7 +170,7 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
 ### Meet the Organizers
 <br />
 
-<p>InnerSource Summit 2026 is brought to you by a volunteer crew who give their time to make the event happen. Thank you to the people organizing this year's summit.</p>
+<p>InnerSource Summit 2026 is brought to you by the crew who make it happen. Thank you to the people organizing this year's summit.</p>
 <br />
 
 <div class="summit-organizers">
@@ -192,12 +192,12 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
   <div class="organizer">
     <img src="/images/events/organizer-placeholder.svg" alt="Winner Bright" />
     <span class="organizer-name">Winner Bright</span>
-    <span class="organizer-role">Publicity</span>
+    <span class="organizer-role">Publicity Director</span>
   </div>
   <div class="organizer">
     <img src="/images/about/Paul_Berschick.jpg" alt="Paul Berschick" />
     <span class="organizer-name">Paul Berschick</span>
-    <span class="organizer-role">Technology</span>
+    <span class="organizer-role">Technology Director</span>
   </div>
   <div class="organizer">
     <img src="/images/about/Jeff_Bailey.png" alt="Jeff Bailey" />


### PR DESCRIPTION
Follow-up tweaks to the **Meet the Organizers** section (from #1240), spotted on the live page.

## Changes

- **Russell Rutledge:** "Sponsorship Director" → **"Executive Director"**
- **Winner Bright:** "Publicity" → **"Publicity Director"**
- **Paul Berschick:** "Technology" → **"Technology Director"**
- **Intro wording:** dropped "a volunteer crew who give their time" - some of the crew are paid - now reads "InnerSource Summit 2026 is brought to you by the crew who make it happen."

Previewed locally and validated with a full `hugo` build before opening.

## Screenshots

_Full-page render of the Summit 2026 page attached below._

<img width="1272" height="6205" alt="isc-2026-fullpage" src="https://github.com/user-attachments/assets/5b1d2f9a-6cff-41d3-8f64-9c54af9dc165" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq27XjrWQcT6KozaV5efcQ
