### PR TITLE
Set Katie Schueths's Summit 2026 role to Operations Director

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -207,7 +207,7 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
   <div class="organizer">
     <img src="/images/about/Katie_Schueths.jpg" alt="Katie Schueths" />
     <span class="organizer-name">Katie Schueths</span>
-    <span class="organizer-role">Program Committee</span>
+    <span class="organizer-role">Operations Director</span>
   </div>
 </div>
 


### PR DESCRIPTION
Follow-up to the **Meet the Organizers** section on the Summit 2026 page.

## Changes

- **Katie Schueths:** "Program Committee" → **"Operations Director"**

Previewed locally and validated with a full `hugo` build before opening.

## Screenshots

_Full-page render of the Summit 2026 page attached below._
<img width="1272" height="6205" alt="isc-2026-fullpage" src="https://github.com/user-attachments/assets/96e79bdd-7ee6-416b-b27a-b6677e25e14c" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq27XjrWQcT6KozaV5efcQ
