### PR TITLE
Reorder Summit 2026 organizer cards

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -185,9 +185,9 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
     <span class="organizer-role">Speaker Coordinator</span>
   </div>
   <div class="organizer">
-    <img src="/images/about/Russell_Rutledge.jpg" alt="Russell Rutledge" />
-    <span class="organizer-name">Russell Rutledge</span>
-    <span class="organizer-role">Executive Director</span>
+    <img src="/images/about/Jeff_Bailey.png" alt="Jeff Bailey" />
+    <span class="organizer-name">Jeff Bailey</span>
+    <span class="organizer-role">Program Committee</span>
   </div>
   <div class="organizer">
     <img src="/images/events/organizer-placeholder.svg" alt="Winner Bright" />
@@ -195,19 +195,19 @@ David Spinks is a Community Leadership Coach who works with founders, execs, and
     <span class="organizer-role">Publicity Director</span>
   </div>
   <div class="organizer">
-    <img src="/images/about/Paul_Berschick.jpg" alt="Paul Berschick" />
-    <span class="organizer-name">Paul Berschick</span>
-    <span class="organizer-role">Technology Director</span>
-  </div>
-  <div class="organizer">
-    <img src="/images/about/Jeff_Bailey.png" alt="Jeff Bailey" />
-    <span class="organizer-name">Jeff Bailey</span>
-    <span class="organizer-role">Program Committee</span>
-  </div>
-  <div class="organizer">
     <img src="/images/about/Katie_Schueths.jpg" alt="Katie Schueths" />
     <span class="organizer-name">Katie Schueths</span>
     <span class="organizer-role">Operations Director</span>
+  </div>
+  <div class="organizer">
+    <img src="/images/about/Russell_Rutledge.jpg" alt="Russell Rutledge" />
+    <span class="organizer-name">Russell Rutledge</span>
+    <span class="organizer-role">Executive Director</span>
+  </div>
+  <div class="organizer">
+    <img src="/images/about/Paul_Berschick.jpg" alt="Paul Berschick" />
+    <span class="organizer-name">Paul Berschick</span>
+    <span class="organizer-role">Technology Director</span>
   </div>
 </div>
 


### PR DESCRIPTION
Follow-up to the **Meet the Organizers** section on the Summit 2026 page.

## Changes

Reorder the organizer cards (no content or role changes):
- **Top row:** Micaela Eller, Olive Cannon, Jeff Bailey, Winner Bright
- **Bottom row:** Katie Schueths, Russell Rutledge, Paul Berschick

Previewed locally and validated with a full `hugo` build before opening.

## Screenshots

_Full-page render of the Summit 2026 page attached below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq27XjrWQcT6KozaV5efcQ

<img width="1272" height="6205" alt="isc-2026-fullpage" src="https://github.com/user-attachments/assets/73a32eb8-09a0-43b0-ad43-10471ba8fbeb" />
