### PR TITLE
Add Scott Hanselman's keynote title/abstract to Summit 2026 page

### DIFF
--- a/content/en/events/isc-2026.md
+++ b/content/en/events/isc-2026.md
@@ -84,6 +84,14 @@ Remember if you want to go fast, go alone. If you want to go far, go together!
 
 Scott Hanselman is Vice President and Member of Technical Staff at Microsoft/GitHub. A software developer for more than 30 years, Scott is an internationally recognized speaker, author, educator, and developer advocate. He has been blogging for more than 20 years, hosts the Hanselminutes podcast and Azure Friday, has written several technical books, and has spoken to more than one million developers worldwide. Based in Portland, Oregon, Scott is passionate about making technology accessible and helping developers build better software together.
 
+**Keynote: What do you build when you can build anything?**
+
+For most of computing history, building software meant negotiating with scarcity: limited memory, limited compute, limited time, and limited access to expertise. Today, those constraints are rapidly falling away. With AI, cloud platforms, open source, and powerful tools, more people can turn an idea into working software faster than ever before.
+
+But when you can build almost anything, the hardest question is no longer *how*. It is *what...and why*.
+
+In this keynote, Scott Hanselman explores what happens when creation becomes abundant. Through stories, code, and practical examples, he examines the new skills that matter: judgment, taste, curiosity, empathy, and the discipline to understand the problem before generating the solution. The future will not belong simply to those who can build the most. It will belong to those who choose carefully, build responsibly, and create things genuinely worth having.
+
 </div>
 </div>
 <br />


### PR DESCRIPTION


## Summary

Adds Scott Hanselman's keynote title and abstract to his speaker bio block on the Summit 2026 event page, per his reply to Jeff Bailey.

**Title:** What do you build when you can build anything?

David Spinks's block and the original August 6 announcement post are untouched - David hasn't sent his topic yet.

## Screenshots

Full-page render of the isc-2026 event page (local Hugo server), Scott Hanselman's block showing the new title and abstract:

<img width="1900" height="8333" alt="isc-2026-fullpage" src="https://github.com/user-attachments/assets/816d5847-8e64-4d22-8261-5920a141ed2e" />

## Test plan

- [x] Previewed locally with `hugo server --buildDrafts --buildFuture`
- [x] Ran a full `hugo --gc --minify` build with no errors
- [x] Confirmed David Spinks's bio and the rest of the page render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Q8XZQaRRTnm3y3EUipE3q
